### PR TITLE
Fix swbus-core infinite rebuild

### DIFF
--- a/crates/swbus-core/build.rs
+++ b/crates/swbus-core/build.rs
@@ -1,7 +1,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let builder = tonic_build::configure().message_attribute("swbus.ServicePath", "#[derive(Eq, Hash)]");
 
-    builder.compile(&["proto/swbus.proto"], &["swbus"])?;
+    let includes: &[&str] = &[];
+    builder.compile(&["proto/swbus.proto"], includes)?;
 
     Ok(())
 }


### PR DESCRIPTION
If you run cargo build twice in a row, swbus-core gets built twice despite not changing. That's because the build script is telling cargo to look for changes in a file that doesn't exist.
```
$ cargo build -vv
...
       Dirty swbus-core v0.1.0 (/home/user/prog/work/sonic-dash-ha/crates/swbus-core): the file `crates/swbus-core/swbus` is missing
...
[swbus-core 0.1.0] cargo:rerun-if-changed=swbus
```

To fix this, I removed this 'includes' parameter from the protobuf compile call, as it is currently unnecessary and causes the problem. 

```rs
// build.rs
fn main() -> Result<(), Box<dyn std::error::Error>> {
    let builder = tonic_build::configure().message_attribute("swbus.ServicePath", "#[derive(Eq, Hash)]");

    builder.compile(&["proto/swbus.proto"], &["swbus"])?;
    //                                      ^^^^^^^^^^

    Ok(())
}
```