### PR TITLE
Small fixes to previous pr, swbus-edge-simplify

### DIFF
--- a/crates/swbus-edge/src/lib.rs
+++ b/crates/swbus-edge/src/lib.rs
@@ -5,3 +5,5 @@ mod message_router;
 pub mod simple_client;
 
 pub use edge_runtime::SwbusEdgeRuntime;
+
+pub use swbus_proto;

--- a/crates/swss-common/src/types/async_util.rs
+++ b/crates/swss-common/src/types/async_util.rs
@@ -29,7 +29,7 @@ pub(crate) use impl_basic_async_method;
 
 macro_rules! impl_read_data_async {
     () => {
-        /// [`read_data`] but tokio-safe async.
+        /// Async version of [`read_data`](Self::read_data). Does not time out or interrupt on signal.
         pub async fn read_data_async(&mut self) -> ::std::io::Result<()> {
             use ::tokio::io::{unix::AsyncFd, Interest};
 


### PR DESCRIPTION
This fixes some unfinished documentation and warnings that were drowned out by the existing warnings. Wish list: don't commit code with any warnings? lets make that checked by ci with `RUSTFLAGS="-D warnings" cargo check` 