### PR TITLE
swss-common: fix warnings and lints, add DbConnector::clone_timeout

### DIFF
--- a/crates/swss-common/src/types.rs
+++ b/crates/swss-common/src/types.rs
@@ -13,7 +13,7 @@ mod zmqserver;
 
 pub use consumerstatetable::ConsumerStateTable;
 pub use cxxstring::{CxxStr, CxxString};
-pub use dbconnector::DbConnector;
+pub use dbconnector::{DbConnectionInfo, DbConnector};
 pub use producerstatetable::ProducerStateTable;
 pub use subscriberstatetable::SubscriberStateTable;
 pub use zmqclient::ZmqClient;

--- a/crates/swss-common/src/types/async_util.rs
+++ b/crates/swss-common/src/types/async_util.rs
@@ -13,6 +13,7 @@ pub(crate) async fn spawn_blocking_scoped<F: FnOnce() -> T + Send, T: Send + 'st
 macro_rules! impl_basic_async_method {
     // Method (with self)
     ($async_fn:ident <= $sync_fn:ident $(<$($generic_decls:tt),*>)? (& $(mut)? self $(, $arg:ident : $typ:ty)*) $(-> $ret_ty:ty)? $(where $($generic_bounds:tt)*)?) => {
+        #[doc = concat!("Async version of [`", stringify!($sync_fn), "`](Self::", stringify!($sync_fn), ") that uses `tokio::task::spawn_blocking`.")]
         pub async fn $async_fn $(<$($generic_decls),*>)? (&mut self $(, $arg: $typ)*) $(-> $ret_ty)? $(where $($generic_bounds)*)? {
             $crate::types::async_util::spawn_blocking_scoped(move || self.$sync_fn($($arg),*)).await
         }
@@ -20,6 +21,7 @@ macro_rules! impl_basic_async_method {
 
     // Associated fn (without self)
     ($async_fn:ident <= $sync_fn:ident $(<$($generic_decls:tt),*>)? ($($arg:ident : $typ:ty),*) $(-> $ret_ty:ty)? $(where $($generic_bounds:tt)*)?) => {
+        #[doc = concat!("Async version of [`", stringify!($sync_fn), "`](Self::", stringify!($sync_fn), ") that uses `tokio::task::spawn_blocking`.")]
         pub async fn $async_fn $(<$($generic_decls),*>)? ($($arg: $typ),*) $(-> $ret_ty)? $(where $($generic_bounds)*)? {
             $crate::types::async_util::spawn_blocking_scoped(move || Self::$sync_fn($($arg),*)).await
         }

--- a/crates/swss-common/src/types/consumerstatetable.rs
+++ b/crates/swss-common/src/types/consumerstatetable.rs
@@ -14,7 +14,7 @@ impl ConsumerStateTable {
         let table_name = cstr(table_name);
         let pop_batch_size = pop_batch_size.as_ref().map(|n| n as *const i32).unwrap_or(null());
         let pri = pri.as_ref().map(|n| n as *const i32).unwrap_or(null());
-        let ptr = unsafe { SWSSConsumerStateTable_new(db.ptr, table_name.as_ptr(), pop_batch_size, pri).into() };
+        let ptr = unsafe { SWSSConsumerStateTable_new(db.ptr, table_name.as_ptr(), pop_batch_size, pri) };
         Self { ptr, _db: db }
     }
 

--- a/crates/swss-common/src/types/dbconnector.rs
+++ b/crates/swss-common/src/types/dbconnector.rs
@@ -139,19 +139,11 @@ impl Drop for DbConnector {
 
 unsafe impl Send for DbConnector {}
 
-impl Clone for DbConnector {
-    /// Clone the `DbConnector` with no timeout.
-    fn clone(&self) -> Self {
-        self.clone_timeout(0)
-    }
-}
-
 #[cfg(feature = "async")]
 impl DbConnector {
     async_util::impl_basic_async_method!(new_tcp_async <= new_tcp(db_id: i32, hostname: &str, port: u16, timeout_ms: u32) -> DbConnector);
     async_util::impl_basic_async_method!(new_unix_async <= new_unix(db_id: i32, sock_path: &str, timeout_ms: u32) -> DbConnector);
     async_util::impl_basic_async_method!(clone_timeout_async <= clone_timeout(&self, timeout_ms: u32) -> DbConnector);
-    async_util::impl_basic_async_method!(clone_async <= clone(&self) -> DbConnector);
     async_util::impl_basic_async_method!(del_async <= del(&self, key: &str) -> bool);
     async_util::impl_basic_async_method!(set_async <= set(&self, key: &str, value: &CxxStr));
     async_util::impl_basic_async_method!(get_async <= get(&self, key: &str) -> Option<CxxString>);

--- a/crates/swss-common/src/types/dbconnector.rs
+++ b/crates/swss-common/src/types/dbconnector.rs
@@ -21,7 +21,7 @@ pub enum DbConnectionInfo {
 impl DbConnector {
     /// Create a new DbConnector from [`DbConnectionInfo`].
     ///
-    /// Timeout of 0 means infinite.
+    /// Timeout of 0 means block indefinitely.
     fn new(db_id: i32, connection: DbConnectionInfo, timeout_ms: u32) -> DbConnector {
         let ptr = match &connection {
             DbConnectionInfo::Tcp { hostname, port } => {
@@ -39,7 +39,7 @@ impl DbConnector {
 
     /// Create a DbConnector over a tcp socket.
     ///
-    /// Timeout of 0 means infinite.
+    /// Timeout of 0 means block indefinitely.
     pub fn new_tcp(db_id: i32, hostname: impl Into<String>, port: u16, timeout_ms: u32) -> DbConnector {
         let hostname = hostname.into();
         Self::new(db_id, DbConnectionInfo::Tcp { hostname, port }, timeout_ms)
@@ -47,7 +47,7 @@ impl DbConnector {
 
     /// Create a DbConnector over a unix socket.
     ///
-    /// Timeout of 0 means infinite.
+    /// Timeout of 0 means block indefinitely.
     pub fn new_unix(db_id: i32, sock_path: impl Into<String>, timeout_ms: u32) -> DbConnector {
         let sock_path = sock_path.into();
         Self::new(db_id, DbConnectionInfo::Unix { sock_path }, timeout_ms)
@@ -55,7 +55,7 @@ impl DbConnector {
 
     /// Clone a DbConnector with a timeout.
     ///
-    /// Timeout of 0 means infinite.
+    /// Timeout of 0 means block indefinitely.
     pub fn clone_timeout(&self, timeout_ms: u32) -> Self {
         Self::new(self.db_id, self.connection.clone(), timeout_ms)
     }

--- a/crates/swss-common/src/types/producerstatetable.rs
+++ b/crates/swss-common/src/types/producerstatetable.rs
@@ -11,7 +11,7 @@ pub struct ProducerStateTable {
 impl ProducerStateTable {
     pub fn new(db: DbConnector, table_name: &str) -> Self {
         let table_name = cstr(table_name);
-        let ptr = unsafe { SWSSProducerStateTable_new(db.ptr, table_name.as_ptr()).into() };
+        let ptr = unsafe { SWSSProducerStateTable_new(db.ptr, table_name.as_ptr()) };
         Self { ptr, _db: db }
     }
 

--- a/crates/swss-common/src/types/subscriberstatetable.rs
+++ b/crates/swss-common/src/types/subscriberstatetable.rs
@@ -14,7 +14,7 @@ impl SubscriberStateTable {
         let table_name = cstr(table_name);
         let pop_batch_size = pop_batch_size.as_ref().map(|n| n as *const i32).unwrap_or(null());
         let pri = pri.as_ref().map(|n| n as *const i32).unwrap_or(null());
-        let ptr = unsafe { SWSSSubscriberStateTable_new(db.ptr, table_name.as_ptr(), pop_batch_size, pri).into() };
+        let ptr = unsafe { SWSSSubscriberStateTable_new(db.ptr, table_name.as_ptr(), pop_batch_size, pri) };
         Self { ptr, _db: db }
     }
 

--- a/crates/swss-common/src/types/zmqclient.rs
+++ b/crates/swss-common/src/types/zmqclient.rs
@@ -10,7 +10,7 @@ pub struct ZmqClient {
 impl ZmqClient {
     pub fn new(endpoint: &str) -> Self {
         let endpoint = cstr(endpoint);
-        let ptr = unsafe { SWSSZmqClient_new(endpoint.as_ptr()).into() };
+        let ptr = unsafe { SWSSZmqClient_new(endpoint.as_ptr()) };
         Self { ptr }
     }
 

--- a/crates/swss-common/src/types/zmqconsumerstatetable.rs
+++ b/crates/swss-common/src/types/zmqconsumerstatetable.rs
@@ -68,7 +68,11 @@ impl Drop for DropGuard {
     }
 }
 
+// SAFETY: This is safe as long as ZmqConsumerStateTable is Send
 unsafe impl Send for DropGuard {}
+
+// SAFETY: There is no way to use &DropGuard so it is safe
+unsafe impl Sync for DropGuard {}
 
 /// Async versions of methods
 #[cfg(feature = "async")]

--- a/crates/swss-common/src/types/zmqserver.rs
+++ b/crates/swss-common/src/types/zmqserver.rs
@@ -18,7 +18,7 @@ pub struct ZmqServer {
 impl ZmqServer {
     pub fn new(endpoint: &str) -> Self {
         let endpoint = cstr(endpoint);
-        let obj = unsafe { SWSSZmqServer_new(endpoint.as_ptr()).into() };
+        let obj = unsafe { SWSSZmqServer_new(endpoint.as_ptr()) };
         Self {
             ptr: obj,
             message_handler_guards: Vec::new(),

--- a/crates/swss-common/tests/async.rs
+++ b/crates/swss-common/tests/async.rs
@@ -37,6 +37,9 @@ async fn dbconnector_async_api_basic_test() {
     let redis = Redis::start();
     let mut db = redis.db_connector();
 
+    drop(db.clone_async().await);
+    drop(db.clone_timeout_async(10000).await);
+
     assert!(db.flush_db_async().await);
 
     let random = random_cxx_string();

--- a/crates/swss-common/tests/async.rs
+++ b/crates/swss-common/tests/async.rs
@@ -37,7 +37,6 @@ async fn dbconnector_async_api_basic_test() {
     let redis = Redis::start();
     let mut db = redis.db_connector();
 
-    drop(db.clone_async().await);
     drop(db.clone_timeout_async(10000).await);
 
     assert!(db.flush_db_async().await);

--- a/crates/swss-common/tests/sync.rs
+++ b/crates/swss-common/tests/sync.rs
@@ -9,6 +9,9 @@ fn dbconnector_sync_api_basic_test() {
     let redis = Redis::start();
     let db = redis.db_connector();
 
+    drop(db.clone());
+    drop(db.clone_timeout(10000));
+
     assert!(db.flush_db());
 
     let random = random_cxx_string();

--- a/crates/swss-common/tests/sync.rs
+++ b/crates/swss-common/tests/sync.rs
@@ -9,7 +9,6 @@ fn dbconnector_sync_api_basic_test() {
     let redis = Redis::start();
     let db = redis.db_connector();
 
-    drop(db.clone());
     drop(db.clone_timeout(10000));
 
     assert!(db.flush_db());


### PR DESCRIPTION
fixed a couple warnings and clippy lints

added clone methods to dbconnector