### PR TITLE
swss-common: Use c_char instead of i8, allowing arm's unsigned char

### DIFF
--- a/crates/swss-common/src/types.rs
+++ b/crates/swss-common/src/types.rs
@@ -44,7 +44,7 @@ pub(crate) fn cstr(s: impl AsRef<[u8]>) -> CString {
 }
 
 /// Take a malloc'd c string and convert it to a native String
-pub(crate) unsafe fn take_cstr(p: *const i8) -> String {
+pub(crate) unsafe fn take_cstr(p: *const libc::c_char) -> String {
     let s = CStr::from_ptr(p)
         .to_str()
         .expect("C string being converted to Rust String contains invalid UTF-8")

--- a/crates/swss-common/src/types/cxxstring.rs
+++ b/crates/swss-common/src/types/cxxstring.rs
@@ -32,7 +32,7 @@ impl CxxString {
     /// Copies the given data into a new C++ string.
     pub fn new(data: impl AsRef<[u8]>) -> CxxString {
         unsafe {
-            let ptr = data.as_ref().as_ptr() as *const i8;
+            let ptr = data.as_ref().as_ptr() as *const libc::c_char;
             let len = data.as_ref().len().try_into().unwrap();
             CxxString::take(SWSSString_new(ptr, len)).unwrap()
         }


### PR DESCRIPTION
Switch to using libc::c_char where c strings are handled, so swss-common can be agnostic to char signedness.