### PR TITLE
Implementing trace-route CLI for debugging reachability

### DIFF
--- a/crates/sonic-common/src/log.rs
+++ b/crates/sonic-common/src/log.rs
@@ -47,10 +47,10 @@ impl LoggerConfigChangeHandler for LoggerConfigHandler {
 
 /// log initialization
 /// There are multiple options to initialize log:
-/// 1. Set RUST_LOG or {program_name}_LOG_LEVEL env var to the desired log level. If the log env is not set and link_swsscommon_logger is false,
-///     use DEFAULT_LOG_LEVEL. Otherwise, use swsscommon logger described next
-/// 2. If link_swsscommon_logger is set, use swsscommon logger to get log settings from config_db, which supports dynamic log level change
-///     by modifying config_db. The settings include
+/// * Set RUST_LOG or {program_name}_LOG_LEVEL env var to the desired log level. If the log env is not set and link_swsscommon_logger is false,
+///   use DEFAULT_LOG_LEVEL. Otherwise, use swsscommon logger described next
+/// * If link_swsscommon_logger is set, use swsscommon logger to get log settings from config_db, which supports dynamic log level change
+///   by modifying config_db. The settings include
 ///   - log_level: emerg, alert, crit, error, warn, notice, info, debug
 ///   - output: stdout, stderr, syslog. Rust doesn't support dynamically changing log output. We will only support default output (syslog in linux, file in windows)
 pub fn init(program_name: &'static str, link_swsscommon_logger: bool) -> Result<()> {

--- a/crates/swbus-cli/README.md
+++ b/crates/swbus-cli/README.md
@@ -48,6 +48,31 @@ Response received: ping_seq=3, ttl=62, time=5.913ms
 Response received: ping_seq=4, ttl=62, time=5.893ms
 ```
 
+## trace-route
+The command is similar to trace-route command in Linux. The request will be routed to the destination. Every hop along the path will send a response back, which allows us to see the path the request going through.
+
+```
+Usage: swbus-cli trace-route [OPTIONS] <DEST>
+
+Arguments:
+  <DEST>  The destination service path of the request
+
+Options:
+  -t, --timeout <TIMEOUT>  Timeout in seconds for each request [default: 1]
+  -c, --max-hop <MAX_HOP>  Max hop count [default: 10]
+  -h, --help               Print help
+```
+
+Here is an example of the command.
+```
+sonic-dash-ha$ target/debug/swbus-cli -c crates/swbusd/sample/swbusd1.cfg trace-route region-a.cluster-a.10.0.0.2-dpu0
+traceroute to region-a.cluster-a.10.0.0.2-dpu0, 10 hops max
+Starting edge runtime with URI: http://127.0.0.1:50001
+Connected to the server
+1  region-a.cluster-a.10.0.0.1-dpu0  5.336ms  1 hops
+2  region-a.cluster-a.10.0.0.2-dpu0  7.757ms  2 hops
+```
+
 ## show route
 The command displays route table in the local swbusd
 ```

--- a/crates/swbus-cli/src/main.rs
+++ b/crates/swbus-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod ping;
 mod show;
+mod trace_route;
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::sync::Arc;
@@ -30,6 +31,7 @@ struct Command {
 #[derive(Parser, Debug)]
 enum CliSubCmd {
     Ping(ping::PingCmd),
+    TraceRoute(trace_route::TraceRouteCmd),
     Show(show::ShowCmd),
 }
 
@@ -182,6 +184,7 @@ async fn main() {
     match args.subcommand {
         CliSubCmd::Ping(ping_args) => ping_args.handle(&ctx).await,
         CliSubCmd::Show(show_args) => show_args.handle(&ctx).await,
+        CliSubCmd::TraceRoute(trace_route_args) => trace_route_args.handle(&ctx).await,
     };
 }
 

--- a/crates/swbus-cli/src/trace_route.rs
+++ b/crates/swbus-cli/src/trace_route.rs
@@ -1,0 +1,93 @@
+use super::CmdHandler;
+use crate::wait_for_response;
+use clap::Parser;
+use std::time::Instant;
+use swbus_proto::swbus::*;
+use tokio::sync::mpsc;
+use tracing::info;
+
+const MAX_HOP: u8 = 10;
+#[derive(Parser, Debug)]
+pub struct TraceRouteCmd {
+    /// Timeout in seconds for each request
+    #[arg(short = 't', long, default_value_t = 1)]
+    timeout: u32,
+
+    /// The destination service path of the request
+    #[arg(value_parser = ServicePath::from_string)]
+    dest: ServicePath,
+}
+
+impl CmdHandler for TraceRouteCmd {
+    async fn handle(&self, ctx: &super::CommandContext) {
+        // Create a channel to receive response
+        let (recv_queue_tx, mut recv_queue_rx) = mpsc::channel::<SwbusMessage>(1);
+        let mut src_sp = ctx.sp.clone();
+        src_sp.resource_type = "traceroute".to_string();
+        src_sp.resource_id = "0".to_string();
+        // Register the channel to the runtime to receive response
+        ctx.runtime.lock().await.add_handler(src_sp.clone(), recv_queue_tx);
+
+        // Send ping messages
+        info!("traceroute to {}, {} hops max", self.dest.to_longest_path(), MAX_HOP);
+
+        let header = SwbusMessageHeader::new(src_sp.clone(), self.dest.clone(), ctx.id_generator.generate());
+        let header_id = header.id;
+        let trace_route_msg = SwbusMessage {
+            header: Some(header),
+            body: Some(swbus_message::Body::TraceRouteRequest(TraceRouteRequest::new())),
+        };
+        let start = Instant::now();
+        ctx.runtime.lock().await.send(trace_route_msg).await.unwrap();
+
+        for i in 0..MAX_HOP {
+            // wait on the channel to receive response or timeout
+            let result = wait_for_response(&mut recv_queue_rx, header_id, self.timeout).await;
+            match result.error_code {
+                SwbusErrorCode::Ok => {
+                    let elapsed = start.elapsed();
+                    let source_sp = result
+                        .msg
+                        .as_ref()
+                        .unwrap()
+                        .header
+                        .as_ref()
+                        .unwrap()
+                        .source
+                        .as_ref()
+                        .unwrap();
+                    info!(
+                        "{}  {}  {:.3}ms  {} hops",
+                        i + 1,
+                        source_sp.to_longest_path(),
+                        elapsed.as_secs_f64() * 1000.0,
+                        (64 - result.msg.as_ref().unwrap().header.as_ref().unwrap().ttl) as u8
+                    );
+                    if source_sp == &self.dest {
+                        break;
+                    }
+                }
+                SwbusErrorCode::Timeout => {
+                    info!("{}  *  *  *", i + 1);
+                }
+                _ => {
+                    let src_sp = match result.msg {
+                        Some(msg) => format!("{}", msg.header.unwrap().source.unwrap().to_longest_path()),
+                        None => "".to_string(),
+                    };
+                    info!(
+                        "{}  {}  {}({})",
+                        i + 1,
+                        src_sp,
+                        result
+                            .error_code
+                            .as_str_name()
+                            .strip_prefix("SWBUS_ERROR_CODE_")
+                            .unwrap_or(result.error_code.as_str_name()),
+                        result.error_message
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/swbus-cli/src/trace_route.rs
+++ b/crates/swbus-cli/src/trace_route.rs
@@ -72,7 +72,7 @@ impl CmdHandler for TraceRouteCmd {
                 }
                 _ => {
                     let src_sp = match result.msg {
-                        Some(msg) => format!("{}", msg.header.unwrap().source.unwrap().to_longest_path()),
+                        Some(msg) => msg.header.unwrap().source.unwrap().to_longest_path().to_string(),
                         None => "".to_string(),
                     };
                     info!(

--- a/crates/swbus-core/tests/basic_tests.rs
+++ b/crates/swbus-core/tests/basic_tests.rs
@@ -11,4 +11,5 @@ async fn test_all() {
     // use the shared runtime. It will panic with "fatal runtime error: thread::set_current should only be called once per thread".
     run_tests(&mut topo, "tests/data/test_ping.json", None).await;
     run_tests(&mut topo, "tests/data/test_show_route.json", None).await;
+    run_tests(&mut topo, "tests/data/test_trace_route.json", None).await;
 }

--- a/crates/swbus-core/tests/data/test_trace_route.json
+++ b/crates/swbus-core/tests/data/test_trace_route.json
@@ -14,7 +14,7 @@
                 "flag": 0,
                 "ttl": 64,
                 "source": "region-a.cluster-a.10.0.0.1-dpu0/testsvc/0/ping/0",
-                "destination": "region-a.cluster-a.10.0.0.2-dpu0/local-mgmt/0"
+                "destination": "region-a.cluster-a.10.0.0.2-dpu0"
               },
               "body": {
                 "TraceRouteRequest": {}
@@ -66,5 +66,73 @@
         ]
       }
     ]
-  }
+  },
+  {
+    "name": "trace_route_with_ttl_expired",
+    "topo": "2-swbusd",
+    "description": "verify trace route and ttl expired",
+    "steps": [
+      {
+        "requests": [
+          {
+            "client": "swbusd1-client",
+            "message": {
+              "header": {
+                "version": 1,
+                "flag": 0,
+                "ttl": 1,
+                "source": "region-a.cluster-a.10.0.0.1-dpu0/testsvc/0/ping/0",
+                "destination": "region-a.cluster-a.10.0.0.2-dpu0"
+              },
+              "body": {
+                "TraceRouteRequest": {}
+              }
+            }
+          }
+        ],
+        "responses": [
+          {
+            "client": "swbusd1-client",
+            "message": {
+              "header": {
+                "version": 1,
+                "flag": 0,
+                "ttl": 63,
+                "source": "region-a.cluster-a.10.0.0.1-dpu0",
+                "destination": "region-a.cluster-a.10.0.0.1-dpu0/testsvc/0/ping/0"
+              },
+              "body": {
+                "Response": {
+                  "request_id": 0,
+                  "error_code": 1,
+                  "error_message": "",
+                  "response_body": null
+                }
+              }
+            }
+          },
+          {
+            "client": "swbusd1-client",
+            "message": {
+              "header": {
+                "version": 1,
+                "flag": 0,
+                "ttl": 63,
+                "source": "region-a.cluster-a.10.0.0.1-dpu0",
+                "destination": "region-a.cluster-a.10.0.0.1-dpu0/testsvc/0/ping/0"
+              },
+              "body": {
+                "Response": {
+                  "request_id": 0,
+                  "error_code": 303,
+                  "error_message": "TTL expired",
+                  "response_body": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }  
 ]

--- a/crates/swbus-core/tests/data/test_trace_route.json
+++ b/crates/swbus-core/tests/data/test_trace_route.json
@@ -1,0 +1,70 @@
+[
+  {
+    "name": "trace_route_request",
+    "topo": "2-swbusd",
+    "description": "verify trace route",
+    "steps": [
+      {
+        "requests": [
+          {
+            "client": "swbusd1-client",
+            "message": {
+              "header": {
+                "version": 1,
+                "flag": 0,
+                "ttl": 64,
+                "source": "region-a.cluster-a.10.0.0.1-dpu0/testsvc/0/ping/0",
+                "destination": "region-a.cluster-a.10.0.0.2-dpu0/local-mgmt/0"
+              },
+              "body": {
+                "TraceRouteRequest": {}
+              }
+            }
+          }
+        ],
+        "responses": [
+          {
+            "client": "swbusd1-client",
+            "message": {
+              "header": {
+                "version": 1,
+                "flag": 0,
+                "ttl": 63,
+                "source": "region-a.cluster-a.10.0.0.1-dpu0",
+                "destination": "region-a.cluster-a.10.0.0.1-dpu0/testsvc/0/ping/0"
+              },
+              "body": {
+                "Response": {
+                  "request_id": 0,
+                  "error_code": 1,
+                  "error_message": "",
+                  "response_body": null
+                }
+              }
+            }
+          },
+          {
+            "client": "swbusd1-client",
+            "message": {
+              "header": {
+                "version": 1,
+                "flag": 0,
+                "ttl": 62,
+                "source": "region-a.cluster-a.10.0.0.2-dpu0",
+                "destination": "region-a.cluster-a.10.0.0.1-dpu0/testsvc/0/ping/0"
+              },
+              "body": {
+                "Response": {
+                  "request_id": 0,
+                  "error_code": 1,
+                  "error_message": "",
+                  "response_body": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/crates/swbus-edge/src/simple_client.rs
+++ b/crates/swbus-edge/src/simple_client.rs
@@ -5,7 +5,7 @@ use swbus_proto::{
     result::Result,
     swbus::{
         swbus_message::Body, DataRequest, RequestResponse, ServicePath, SwbusErrorCode, SwbusMessage,
-        SwbusMessageHeader, TraceRouteRequest, TraceRouteResponse,
+        SwbusMessageHeader,
     },
 };
 use tokio::sync::{
@@ -92,12 +92,10 @@ impl SimpleSwbusEdgeClient {
                 SwbusMessageHeader::new(destination, source, self.id_generator.generate()),
                 Body::Response(RequestResponse::ok(id)),
             )),
-            Body::TraceRouteRequest(TraceRouteRequest { trace_id }) => {
-                HandleReceivedMessage::Respond(SwbusMessage::new(
-                    SwbusMessageHeader::new(destination, source, self.id_generator.generate()),
-                    Body::TraceRouteResponse(TraceRouteResponse { trace_id }),
-                ))
-            }
+            Body::TraceRouteRequest(_) => HandleReceivedMessage::Respond(SwbusMessage::new(
+                SwbusMessageHeader::new(destination, source, self.id_generator.generate()),
+                Body::Response(RequestResponse::ok(id)),
+            )),
             _ => HandleReceivedMessage::Ignore,
         }
     }

--- a/crates/swbus-proto/proto/swbus.proto
+++ b/crates/swbus-proto/proto/swbus.proto
@@ -196,14 +196,9 @@ message RouteQueryResultEntry {
 message PingRequest {}
 
 //
-// Trace route request and response.
+// Trace route request
 //
 message TraceRouteRequest {
-  string trace_id = 10;
-}
-
-message TraceRouteResponse {
-  string trace_id = 10;
 }
 
 message ManagementRequestArg {
@@ -244,7 +239,6 @@ message SwbusMessage {
 
     // Trace route
     TraceRouteRequest trace_route_request = 410;
-    TraceRouteResponse trace_route_response = 420;
 
     // Management request
     ManagementRequest management_request = 510;

--- a/crates/swbus-proto/src/swbus.rs
+++ b/crates/swbus-proto/src/swbus.rs
@@ -326,7 +326,7 @@ impl SwbusMessage {
     /// send response to the sender of the request
     pub fn new_response(
         request: &SwbusMessage,
-        dest: Option<&ServicePath>,
+        source: Option<&ServicePath>,
         error_code: SwbusErrorCode,
         error_message: &str,
         request_id: u64,
@@ -342,7 +342,7 @@ impl SwbusMessage {
         };
 
         // if dest is not provided, use the source of the request
-        let dest_sp = match dest {
+        let src_sp = match source {
             Some(sp) => sp.clone(),
             None => request
                 .header
@@ -355,7 +355,7 @@ impl SwbusMessage {
 
         SwbusMessage {
             header: Some(SwbusMessageHeader::new(
-                dest_sp,
+                src_sp,
                 request
                     .header
                     .as_ref()
@@ -376,18 +376,8 @@ impl PingRequest {
 }
 
 impl TraceRouteRequest {
-    pub fn new(trace_id: &str) -> Self {
-        TraceRouteRequest {
-            trace_id: trace_id.to_string(),
-        }
-    }
-}
-
-impl TraceRouteResponse {
-    pub fn new(trace_id: &str) -> Self {
-        TraceRouteResponse {
-            trace_id: trace_id.to_string(),
-        }
+    pub fn new() -> Self {
+        TraceRouteRequest {}
     }
 }
 
@@ -488,14 +478,8 @@ mod tests {
 
     #[test]
     fn trace_route_request_can_be_created() {
-        let request = TraceRouteRequest::new("mock-trace-id");
+        let request = TraceRouteRequest::new();
         test_packing_with_swbus_message(swbus_message::Body::TraceRouteRequest(request));
-    }
-
-    #[test]
-    fn trace_route_response_can_be_created() {
-        let response = TraceRouteResponse::new("mock-trace-id");
-        test_packing_with_swbus_message(swbus_message::Body::TraceRouteResponse(response));
     }
 
     #[test]


### PR DESCRIPTION
### why
Per swbusd wiki, we use trace route cli for troubleshooting.

### what this PR does
Implement trace route cli and unit tests
Removed trace_id in TraceRouteRequest because we can use request_id for tracking purpose. For the same reason, TraceRouteResponse is removed because we can use standard Response message.