### PR TITLE
Test utils to test hamgrd in local workspace

### DIFF
--- a/test_utils/README.md
+++ b/test_utils/README.md
@@ -2,14 +2,19 @@ This folder contains some utilities, configurations, instructions on running man
 
 # Run hamgrd, swbusd and swbus-cli
 - Start redis db
+
     cd test_utils
+    
     ./run_redis.sh hamgrd/database_config.json hamgrd/redis_data_set.cmd 
 
 - Start swbusd
+
     target/debug/swbusd -s 0
 
 - Start hamgrd
+
     target/debug/hamgrd -s 0
 
 - Run swbus-cli
+
     DEV=dpu0 target/debug/swbus-cli show hamgrd actor /hamgrd/0/dpu/switch1_dpu0

--- a/test_utils/README.md
+++ b/test_utils/README.md
@@ -1,0 +1,15 @@
+This folder contains some utilities, configurations, instructions on running manual test in development environment.
+
+# Run hamgrd, swbusd and swbus-cli
+- Start redis db
+    cd test_utils
+    ./run_redis.sh hamgrd/database_config.json hamgrd/redis_data_set.cmd 
+
+- Start swbusd
+    target/debug/swbusd -s 0
+
+- Start hamgrd
+    target/debug/hamgrd -s 0
+
+- Run swbus-cli
+    DEV=dpu0 target/debug/swbus-cli show hamgrd actor /hamgrd/0/dpu/switch1_dpu0

--- a/test_utils/hamgrd/database_config.json
+++ b/test_utils/hamgrd/database_config.json
@@ -14,28 +14,28 @@
             "instance": "redis"
         },
         "CONFIG_DB": {
-            "id": 1,
-            "separator": "|",
-            "instance": "redis"
-        },
-        "STATE_DB": {
-            "id": 2,
-            "separator": "|",
-            "instance": "redis"
-        },
-        "CHASSIS_STATE_DB": {
-            "id": 3,
-            "separator": "|",
-            "instance": "redis"
-        },
-        "DPU_STATE_DB": {
             "id": 4,
             "separator": "|",
             "instance": "redis"
         },
+        "STATE_DB": {
+            "id": 6,
+            "separator": "|",
+            "instance": "redis"
+        },
+        "CHASSIS_STATE_DB": {
+            "id": 13,
+            "separator": "|",
+            "instance": "redis"
+        },
         "DPU_APPL_DB": {
-            "id": 5,
+            "id": 15,
             "separator": ":",
+            "instance": "redis"
+        },
+        "DPU_STATE_DB": {
+            "id": 17,
+            "separator": "|",
             "instance": "redis"
         }
     }

--- a/test_utils/hamgrd/database_config.json
+++ b/test_utils/hamgrd/database_config.json
@@ -35,8 +35,8 @@
         },
         "DPU_APPL_DB": {
             "id": 5,
-            "separator": "|",
+            "separator": ":",
             "instance": "redis"
-        }        
+        }
     }
 }

--- a/test_utils/hamgrd/database_config.json
+++ b/test_utils/hamgrd/database_config.json
@@ -19,7 +19,7 @@
             "instance": "redis"
         },
         "STATE_DB": {
-            "id": 6,
+            "id": 2,
             "separator": "|",
             "instance": "redis"
         },
@@ -32,6 +32,11 @@
             "id": 4,
             "separator": "|",
             "instance": "redis"
-        }
+        },
+        "DPU_APPL_DB": {
+            "id": 5,
+            "separator": "|",
+            "instance": "redis"
+        }        
     }
 }

--- a/test_utils/hamgrd/database_config.json
+++ b/test_utils/hamgrd/database_config.json
@@ -1,0 +1,37 @@
+{
+    "INSTANCES": {
+        "redis": {
+            "hostname": "127.0.0.1",
+            "port": 6379,
+            "unix_socket_path": "/var/run/redis/redis.sock",
+            "persistence_for_warm_boot": "yes"
+        }
+    },
+    "DATABASES": {
+        "APPL_DB": {
+            "id": 0,
+            "separator": ":",
+            "instance": "redis"
+        },
+        "CONFIG_DB": {
+            "id": 1,
+            "separator": "|",
+            "instance": "redis"
+        },
+        "STATE_DB": {
+            "id": 6,
+            "separator": "|",
+            "instance": "redis"
+        },
+        "CHASSIS_STATE_DB": {
+            "id": 3,
+            "separator": "|",
+            "instance": "redis"
+        },
+        "DPU_STATE_DB": {
+            "id": 4,
+            "separator": "|",
+            "instance": "redis"
+        }
+    }
+}

--- a/test_utils/hamgrd/redis_data_planned_up_then_down.cmd
+++ b/test_utils/hamgrd/redis_data_planned_up_then_down.cmd
@@ -1,21 +1,21 @@
 # execute below commands in redis-cli to simulate the flow in planned ha up
 # approved_pending_operation_ids needs to be updated with the actual value from STATE_DB/DASH_HA_SCOPE_STATE
-select 4
+select 17
 HSET DASH_HA_SCOPE_STATE|haset0_0 last_updated_time "1718053542000" ha_role "dead" ha_role_start_time "1718053542000" ha_term "1" activate_role_pending "false" flow_reconcile_pending "false" brainsplit_recover_pending "false"
 
 select 0
-HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 disable "true"
+HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 disable "false"
 
-select 4
+select 17
 HSET DASH_HA_SCOPE_STATE|haset0_0 activate_role_pending "true"
 
 select 0
 HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 version "3" approved_pending_operation_ids "8dda84ea-fdb4-4edd-b88c-55fc96d02a6f"
 
-select 4
+select 17
 HSET DASH_HA_SCOPE_STATE|haset0_0 activate_role_pending "false" ha_role "active" ha_role_start_time "1718053552000" ha_term "2"
 
-select 4
+select 17
 HSET DASH_BFD_PROBE_STATE|dpu0 v4_bfd_up_sessions "10.1.0.3"
 
 

--- a/test_utils/hamgrd/redis_data_planned_up_then_down.cmd
+++ b/test_utils/hamgrd/redis_data_planned_up_then_down.cmd
@@ -1,0 +1,24 @@
+# execute below commands in redis-cli to simulate the flow in planned ha up
+# approved_pending_operation_ids needs to be updated with the actual value from STATE_DB/DASH_HA_SCOPE_STATE
+select 4
+HSET DASH_HA_SCOPE_STATE|haset0_0 last_updated_time "1718053542000" ha_role "dead" ha_role_start_time "1718053542000" ha_term "1" activate_role_pending "false" flow_reconcile_pending "false" brainsplit_recover_pending "false"
+
+select 0
+HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 disable "true"
+
+select 4
+HSET DASH_HA_SCOPE_STATE|haset0_0 activate_role_pending "true"
+
+select 0
+HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 version "3" approved_pending_operation_ids "8dda84ea-fdb4-4edd-b88c-55fc96d02a6f"
+
+select 4
+HSET DASH_HA_SCOPE_STATE|haset0_0 activate_role_pending "false" ha_role "active" ha_role_start_time "1718053552000" ha_term "2"
+
+select 4
+HSET DASH_BFD_PROBE_STATE|dpu0 v4_bfd_up_sessions "10.1.0.3"
+
+
+# execute below commands in redis-cli to simulate the flow in planned ha down
+select 0
+HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 version "3" desired_ha_state "dead"

--- a/test_utils/hamgrd/redis_data_set.cmd
+++ b/test_utils/hamgrd/redis_data_set.cmd
@@ -78,5 +78,10 @@ HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 pinned_vdpu_bfd_probe_states ""
 HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 preferred_vdpu_ids "vdpu0"
 HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 preferred_standalone_vdpu_index "0"
 
+HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 version "1"
+HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 disable "true"
+HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 desired_ha_state "active"
+HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 approved_pending_operation_ids ""
+
 #select 4
 #HSET DASH_BFD_PROBE_STATE|dpu0 v4_bfd_up_sessions "10.1.0.32"

--- a/test_utils/hamgrd/redis_data_set.cmd
+++ b/test_utils/hamgrd/redis_data_set.cmd
@@ -82,6 +82,3 @@ HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 version "1"
 HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 disable "true"
 HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 desired_ha_state "active"
 HSET DASH_HA_SCOPE_CONFIG_TABLE:vdpu0:haset0_0 approved_pending_operation_ids ""
-
-#select 4
-#HSET DASH_BFD_PROBE_STATE|dpu0 v4_bfd_up_sessions "10.1.0.32"

--- a/test_utils/hamgrd/redis_data_set.cmd
+++ b/test_utils/hamgrd/redis_data_set.cmd
@@ -2,39 +2,44 @@ select 1
 hset DEVICE_METADATA|localhost region region-a cluster cluster-a
 HSET "LOOPBACK_INTERFACE|Loopback0|127.0.0.1/32" "NULL" "NULL"
 hset LOOPBACK_INTERFACE|Loopback0 NULL NULL
-HSET "DPU|switch1_dpu0" "dpu_id" "0"
-HSET "DPU|switch1_dpu0" "gnmi_port" "50051"
-HSET "DPU|switch1_dpu0" "local_port" "8080"
-HSET "DPU|switch1_dpu0" "orchagent_zmq_port" "5555"
-HSET "DPU|switch1_dpu0" "pa_ipv4" "18.0.202.1"
-HSET "DPU|switch1_dpu0" "state" "up"
-HSET "DPU|switch1_dpu0" "swbus_port" "23606"
-HSET "DPU|switch1_dpu0" "vdpu_id" "vdpu0"
-HSET "DPU|switch1_dpu0" "vip_ipv4" "3.2.1.0"
-HSET "DPU|switch1_dpu0" "midplane_ipv4" "169.254.0.1"
+HSET "DPU|switch0_dpu0" "dpu_id" "0"
+HSET "DPU|switch0_dpu0" "gnmi_port" "50051"
+HSET "DPU|switch0_dpu0" "local_port" "8080"
+HSET "DPU|switch0_dpu0" "orchagent_zmq_port" "5555"
+HSET "DPU|switch0_dpu0" "pa_ipv4" "18.0.202.1"
+HSET "DPU|switch0_dpu0" "state" "up"
+HSET "DPU|switch0_dpu0" "swbus_port" "23606"
+HSET "DPU|switch0_dpu0" "vdpu_id" "vdpu0"
+HSET "DPU|switch0_dpu0" "vip_ipv4" "3.2.1.0"
+HSET "DPU|switch0_dpu0" "midplane_ipv4" "169.254.0.1"
 
-HSET "REMOTE_DPU|switch2_dpu0" "dpu_id" "0"
-HSET "REMOTE_DPU|switch2_dpu0" "type" "cluster"
-HSET "REMOTE_DPU|switch2_dpu0" "npu_ipv4" "10.1.0.2"
-HSET "REMOTE_DPU|switch2_dpu0" "pa_ipv4" "18.1.202.1"
-HSET "REMOTE_DPU|switch2_dpu0" "swbus_port" "23606"
-HSET "REMOTE_DPU|switch2_dpu1" "dpu_id" "1"
-HSET "REMOTE_DPU|switch2_dpu1" "type" "cluster"
-HSET "REMOTE_DPU|switch2_dpu1" "swbus_port" "23607"
-HSET "REMOTE_DPU|switch2_dpu1" "npu_ipv4" "10.1.0.2"
-HSET "REMOTE_DPU|switch2_dpu1" "pa_ipv4" "18.1.202.2"
+HSET "REMOTE_DPU|switch1_dpu0" "dpu_id" "0"
+HSET "REMOTE_DPU|switch1_dpu0" "type" "cluster"
+HSET "REMOTE_DPU|switch1_dpu0" "npu_ipv4" "10.1.0.2"
+HSET "REMOTE_DPU|switch1_dpu0" "pa_ipv4" "18.1.202.1"
+HSET "REMOTE_DPU|switch1_dpu0" "swbus_port" "23606"
+HSET "REMOTE_DPU|switch1_dpu1" "dpu_id" "1"
+HSET "REMOTE_DPU|switch1_dpu1" "type" "cluster"
+HSET "REMOTE_DPU|switch1_dpu1" "swbus_port" "23607"
+HSET "REMOTE_DPU|switch1_dpu1" "npu_ipv4" "10.1.0.2"
+HSET "REMOTE_DPU|switch1_dpu1" "pa_ipv4" "18.1.202.2"
 HSET "REMOTE_DPU|switch3_dpu0" "dpu_id" "0"
 HSET "REMOTE_DPU|switch3_dpu0" "type" "cluster"
 HSET "REMOTE_DPU|switch3_dpu0" "npu_ipv4" "10.1.0.3"
 HSET "REMOTE_DPU|switch3_dpu0" "pa_ipv4" "18.2.202.1"
 HSET "REMOTE_DPU|switch3_dpu0" "swbus_port" "23606"
 
-HSET "VDPU|vdpu0" "main_dpu_ids" "switch1_dpu0"
-HSET "VDPU|vdpu1" "main_dpu_ids" "switch2_dpu0"
+HSET "VDPU|vdpu0" "main_dpu_ids" "switch0_dpu0"
+HSET "VDPU|vdpu1" "main_dpu_ids" "switch1_dpu0"
 
 HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_interval_in_ms" "1000"
-HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_multiplier" "3" 
-
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_multiplier" "3"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "cp_data_channel_port" "6000"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_dst_port" "7000"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_src_port_min" "7001"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_src_port_max" "7010"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_probe_interval_ms" "500"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_probe_fail_threshold" "5"
 
 select 3
 HSET DPU_STATE|dpu0 dpu_midplane_link_state up
@@ -62,5 +67,16 @@ HSET DPU_STATE|dpu7 dpu_midplane_link_state up
 HSET DPU_STATE|dpu7 dpu_control_plane_state up
 HSET DPU_STATE|dpu7 dpu_data_plane_state up
 
-select 4
-HSET DASH_BFD_PROBE_STATE|dpu0 v4_bfd_up_sessions "10.1.0.32"
+select 0
+HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 version "1"
+HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 vip_v4 "3.2.1.0"
+HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 vip_v6 ""
+HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 owner "dpu"
+HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 scope "dpu"
+HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 vdpu_ids "vdpu0,vdpu1"
+HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 pinned_vdpu_bfd_probe_states ""
+HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 preferred_vdpu_ids "vdpu0"
+HSET DASH_HA_SET_CONFIG_TABLE:haset0_0 preferred_standalone_vdpu_index "0"
+
+#select 4
+#HSET DASH_BFD_PROBE_STATE|dpu0 v4_bfd_up_sessions "10.1.0.32"

--- a/test_utils/hamgrd/redis_data_set.cmd
+++ b/test_utils/hamgrd/redis_data_set.cmd
@@ -1,4 +1,4 @@
-select 1
+select 4
 hset DEVICE_METADATA|localhost region region-a cluster cluster-a
 HSET "LOOPBACK_INTERFACE|Loopback0|127.0.0.1/32" "NULL" "NULL"
 hset LOOPBACK_INTERFACE|Loopback0 NULL NULL
@@ -41,7 +41,7 @@ HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_src_port_max" "7010"
 HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_probe_interval_ms" "500"
 HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_probe_fail_threshold" "5"
 
-select 3
+select 13
 HSET DPU_STATE|dpu0 dpu_midplane_link_state up
 HSET DPU_STATE|dpu0 dpu_control_plane_state up
 HSET DPU_STATE|dpu0 dpu_data_plane_state up

--- a/test_utils/hamgrd/redis_data_set.cmd
+++ b/test_utils/hamgrd/redis_data_set.cmd
@@ -1,0 +1,66 @@
+select 1
+hset DEVICE_METADATA|localhost region region-a cluster cluster-a
+HSET "LOOPBACK_INTERFACE|Loopback0|127.0.0.1/32" "NULL" "NULL"
+hset LOOPBACK_INTERFACE|Loopback0 NULL NULL
+HSET "DPU|switch1_dpu0" "dpu_id" "0"
+HSET "DPU|switch1_dpu0" "gnmi_port" "50051"
+HSET "DPU|switch1_dpu0" "local_port" "8080"
+HSET "DPU|switch1_dpu0" "orchagent_zmq_port" "5555"
+HSET "DPU|switch1_dpu0" "pa_ipv4" "18.0.202.1"
+HSET "DPU|switch1_dpu0" "state" "up"
+HSET "DPU|switch1_dpu0" "swbus_port" "23606"
+HSET "DPU|switch1_dpu0" "vdpu_id" "vdpu0"
+HSET "DPU|switch1_dpu0" "vip_ipv4" "3.2.1.0"
+HSET "DPU|switch1_dpu0" "midplane_ipv4" "169.254.0.1"
+
+HSET "REMOTE_DPU|switch2_dpu0" "dpu_id" "0"
+HSET "REMOTE_DPU|switch2_dpu0" "type" "cluster"
+HSET "REMOTE_DPU|switch2_dpu0" "npu_ipv4" "10.1.0.2"
+HSET "REMOTE_DPU|switch2_dpu0" "pa_ipv4" "18.1.202.1"
+HSET "REMOTE_DPU|switch2_dpu0" "swbus_port" "23606"
+HSET "REMOTE_DPU|switch2_dpu1" "dpu_id" "1"
+HSET "REMOTE_DPU|switch2_dpu1" "type" "cluster"
+HSET "REMOTE_DPU|switch2_dpu1" "swbus_port" "23607"
+HSET "REMOTE_DPU|switch2_dpu1" "npu_ipv4" "10.1.0.2"
+HSET "REMOTE_DPU|switch2_dpu1" "pa_ipv4" "18.1.202.2"
+HSET "REMOTE_DPU|switch3_dpu0" "dpu_id" "0"
+HSET "REMOTE_DPU|switch3_dpu0" "type" "cluster"
+HSET "REMOTE_DPU|switch3_dpu0" "npu_ipv4" "10.1.0.3"
+HSET "REMOTE_DPU|switch3_dpu0" "pa_ipv4" "18.2.202.1"
+HSET "REMOTE_DPU|switch3_dpu0" "swbus_port" "23606"
+
+HSET "VDPU|vdpu0" "main_dpu_ids" "switch1_dpu0"
+HSET "VDPU|vdpu1" "main_dpu_ids" "switch2_dpu0"
+
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_interval_in_ms" "1000"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_multiplier" "3" 
+
+
+select 3
+HSET DPU_STATE|dpu0 dpu_midplane_link_state up
+HSET DPU_STATE|dpu0 dpu_control_plane_state up
+HSET DPU_STATE|dpu0 dpu_data_plane_state up
+HSET DPU_STATE|dpu1 dpu_midplane_link_state up
+HSET DPU_STATE|dpu1 dpu_control_plane_state up
+HSET DPU_STATE|dpu1 dpu_data_plane_state up
+HSET DPU_STATE|dpu2 dpu_midplane_link_state up
+HSET DPU_STATE|dpu2 dpu_control_plane_state up
+HSET DPU_STATE|dpu2 dpu_data_plane_state up
+HSET DPU_STATE|dpu3 dpu_midplane_link_state up
+HSET DPU_STATE|dpu3 dpu_control_plane_state up
+HSET DPU_STATE|dpu3 dpu_data_plane_state up
+HSET DPU_STATE|dpu4 dpu_midplane_link_state up
+HSET DPU_STATE|dpu4 dpu_control_plane_state up
+HSET DPU_STATE|dpu4 dpu_data_plane_state up
+HSET DPU_STATE|dpu5 dpu_midplane_link_state up
+HSET DPU_STATE|dpu5 dpu_control_plane_state up
+HSET DPU_STATE|dpu5 dpu_data_plane_state up
+HSET DPU_STATE|dpu6 dpu_midplane_link_state up
+HSET DPU_STATE|dpu6 dpu_control_plane_state up
+HSET DPU_STATE|dpu6 dpu_data_plane_state up
+HSET DPU_STATE|dpu7 dpu_midplane_link_state up
+HSET DPU_STATE|dpu7 dpu_control_plane_state up
+HSET DPU_STATE|dpu7 dpu_data_plane_state up
+
+select 4
+HSET DASH_BFD_PROBE_STATE|dpu0 v4_bfd_up_sessions "10.1.0.32"

--- a/test_utils/hamgrd/redis_data_set_full.cmd
+++ b/test_utils/hamgrd/redis_data_set_full.cmd
@@ -1,4 +1,4 @@
-select 1
+select 4
 hset DEVICE_METADATA|localhost region region-a cluster cluster-a
 HSET "LOOPBACK_INTERFACE|Loopback0|127.0.0.1/32" "NULL" "NULL"
 hset LOOPBACK_INTERFACE|Loopback0 NULL NULL
@@ -104,10 +104,10 @@ HSET "REMOTE_DPU|switch3_dpu0" "npu_ipv4" "10.1.0.3"
 HSET "REMOTE_DPU|switch3_dpu0" "swbus_port" "23606"
 
 HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_interval_in_ms" "1000"
-HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_multiplier" "3" 
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_multiplier" "3"
 
 
-select 3
+select 13
 HSET DPU_STATE|dpu0 dpu_midplane_link_state up
 HSET DPU_STATE|dpu0 dpu_control_plane_state up
 HSET DPU_STATE|dpu0 dpu_data_plane_state up
@@ -133,5 +133,5 @@ HSET DPU_STATE|dpu7 dpu_midplane_link_state up
 HSET DPU_STATE|dpu7 dpu_control_plane_state up
 HSET DPU_STATE|dpu7 dpu_data_plane_state up
 
-select 4
+select 17
 HSET DASH_BFD_PROBE_STATE|dpu0 v4_bfd_up_sessions "10.1.0.32"

--- a/test_utils/hamgrd/redis_data_set_full.cmd
+++ b/test_utils/hamgrd/redis_data_set_full.cmd
@@ -1,0 +1,137 @@
+select 1
+hset DEVICE_METADATA|localhost region region-a cluster cluster-a
+HSET "LOOPBACK_INTERFACE|Loopback0|127.0.0.1/32" "NULL" "NULL"
+hset LOOPBACK_INTERFACE|Loopback0 NULL NULL
+HSET "DPU|dpu0" "dpu_id" "0"
+HSET "DPU|dpu0" "gnmi_port" "50051"
+HSET "DPU|dpu0" "local_port" "8080"
+HSET "DPU|dpu0" "orchagent_zmq_port" "5555"
+HSET "DPU|dpu0" "pa_ipv4" "18.0.202.1"
+HSET "DPU|dpu0" "state" "up"
+HSET "DPU|dpu0" "swbus_port" "23606"
+HSET "DPU|dpu0" "vdpu_id" "vdpu0"
+HSET "DPU|dpu0" "vip_ipv4" "3.2.1.0"
+HSET "DPU|dpu0" "midplane_ipv4" "169.254.0.1"
+
+HSET "DPU|dpu1" "dpu_id" "1"
+HSET "DPU|dpu1" "gnmi_port" "50051"
+HSET "DPU|dpu1" "local_port" "8080"
+HSET "DPU|dpu1" "orchagent_zmq_port" "5555"
+HSET "DPU|dpu1" "pa_ipv4" "18.1.202.1"
+HSET "DPU|dpu1" "state" "up"
+HSET "DPU|dpu1" "swbus_port" "23607"
+HSET "DPU|dpu1" "vdpu_id" "vdpu1"
+HSET "DPU|dpu1" "vip_ipv4" "3.2.1.1"
+HSET "DPU|dpu1" "midplane_ipv4" "169.254.1.1"
+
+HSET "DPU|dpu2" "dpu_id" "2"
+HSET "DPU|dpu2" "gnmi_port" "50051"
+HSET "DPU|dpu2" "local_port" "8080"
+HSET "DPU|dpu2" "orchagent_zmq_port" "5555"
+HSET "DPU|dpu2" "pa_ipv4" "18.2.202.1"
+HSET "DPU|dpu2" "state" "up"
+HSET "DPU|dpu2" "swbus_port" "23608"
+HSET "DPU|dpu2" "vdpu_id" "vdpu2"
+HSET "DPU|dpu2" "vip_ipv4" "3.2.1.2"
+HSET "DPU|dpu2" "midplane_ipv4" "169.254.2.1"
+
+HSET "DPU|dpu3" "dpu_id" "3"
+HSET "DPU|dpu3" "gnmi_port" "50051"
+HSET "DPU|dpu3" "local_port" "8080"
+HSET "DPU|dpu3" "orchagent_zmq_port" "5555"
+HSET "DPU|dpu3" "pa_ipv4" "18.3.202.1"
+HSET "DPU|dpu3" "state" "up"
+HSET "DPU|dpu3" "swbus_port" "23609"
+HSET "DPU|dpu3" "vdpu_id" "vdpu3"
+HSET "DPU|dpu3" "vip_ipv4" "3.2.1.3"
+HSET "DPU|dpu3" "midplane_ipv4" "169.254.3.1"
+
+HSET "DPU|dpu4" "dpu_id" "4"
+HSET "DPU|dpu4" "gnmi_port" "50051"
+HSET "DPU|dpu4" "local_port" "8080"
+HSET "DPU|dpu4" "orchagent_zmq_port" "5555"
+HSET "DPU|dpu4" "pa_ipv4" "18.4.202.1"
+HSET "DPU|dpu4" "state" "up"
+HSET "DPU|dpu4" "swbus_port" "23610"
+HSET "DPU|dpu4" "vdpu_id" "vdpu4"
+HSET "DPU|dpu4" "vip_ipv4" "3.2.1.4"
+HSET "DPU|dpu4" "midplane_ipv4" "169.254.4.1"
+
+HSET "DPU|dpu5" "dpu_id" "5"
+HSET "DPU|dpu5" "gnmi_port" "50051"
+HSET "DPU|dpu5" "local_port" "8080"
+HSET "DPU|dpu5" "orchagent_zmq_port" "5555"
+HSET "DPU|dpu5" "pa_ipv4" "18.5.202.1"
+HSET "DPU|dpu5" "state" "up"
+HSET "DPU|dpu5" "swbus_port" "23611"
+HSET "DPU|dpu5" "vdpu_id" "vdpu5"
+HSET "DPU|dpu5" "vip_ipv4" "3.2.1.5"
+HSET "DPU|dpu5" "midplane_ipv4" "169.254.5.1"
+
+HSET "DPU|dpu6" "dpu_id" "6"
+HSET "DPU|dpu6" "gnmi_port" "50051"
+HSET "DPU|dpu6" "local_port" "8080"
+HSET "DPU|dpu6" "orchagent_zmq_port" "5555"
+HSET "DPU|dpu6" "pa_ipv4" "18.6.202.1"
+HSET "DPU|dpu6" "state" "up"
+HSET "DPU|dpu6" "swbus_port" "23612"
+HSET "DPU|dpu6" "vdpu_id" "vdpu6"
+HSET "DPU|dpu6" "vip_ipv4" "3.2.1.6"
+HSET "DPU|dpu6" "midplane_ipv4" "169.254.6.1"
+
+HSET "DPU|dpu7" "dpu_id" "7"
+HSET "DPU|dpu7" "gnmi_port" "50051"
+HSET "DPU|dpu7" "local_port" "8080"
+HSET "DPU|dpu7" "orchagent_zmq_port" "5555"
+HSET "DPU|dpu7" "pa_ipv4" "18.7.202.1"
+HSET "DPU|dpu7" "state" "up"
+HSET "DPU|dpu7" "swbus_port" "23613"
+HSET "DPU|dpu7" "vdpu_id" "vdpu7"
+HSET "DPU|dpu7" "vip_ipv4" "3.2.1.7"
+HSET "DPU|dpu7" "midplane_ipv4" "169.254.7.1"
+
+HSET "REMOTE_DPU|switch2_dpu0" "dpu_id" "0"
+HSET "REMOTE_DPU|switch2_dpu0" "type" "cluster"
+HSET "REMOTE_DPU|switch2_dpu0" "npu_ipv4" "10.1.0.2"
+HSET "REMOTE_DPU|switch2_dpu0" "swbus_port" "23606"
+HSET "REMOTE_DPU|switch2_dpu1" "dpu_id" "1"
+HSET "REMOTE_DPU|switch2_dpu1" "type" "cluster"
+HSET "REMOTE_DPU|switch2_dpu1" "swbus_port" "23607"
+HSET "REMOTE_DPU|switch2_dpu1" "npu_ipv4" "10.1.0.2"
+HSET "REMOTE_DPU|switch3_dpu0" "dpu_id" "0"
+HSET "REMOTE_DPU|switch3_dpu0" "type" "cluster"
+HSET "REMOTE_DPU|switch3_dpu0" "npu_ipv4" "10.1.0.3"
+HSET "REMOTE_DPU|switch3_dpu0" "swbus_port" "23606"
+
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_interval_in_ms" "1000"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_multiplier" "3" 
+
+
+select 3
+HSET DPU_STATE|dpu0 dpu_midplane_link_state up
+HSET DPU_STATE|dpu0 dpu_control_plane_state up
+HSET DPU_STATE|dpu0 dpu_data_plane_state up
+HSET DPU_STATE|dpu1 dpu_midplane_link_state up
+HSET DPU_STATE|dpu1 dpu_control_plane_state up
+HSET DPU_STATE|dpu1 dpu_data_plane_state up
+HSET DPU_STATE|dpu2 dpu_midplane_link_state up
+HSET DPU_STATE|dpu2 dpu_control_plane_state up
+HSET DPU_STATE|dpu2 dpu_data_plane_state up
+HSET DPU_STATE|dpu3 dpu_midplane_link_state up
+HSET DPU_STATE|dpu3 dpu_control_plane_state up
+HSET DPU_STATE|dpu3 dpu_data_plane_state up
+HSET DPU_STATE|dpu4 dpu_midplane_link_state up
+HSET DPU_STATE|dpu4 dpu_control_plane_state up
+HSET DPU_STATE|dpu4 dpu_data_plane_state up
+HSET DPU_STATE|dpu5 dpu_midplane_link_state up
+HSET DPU_STATE|dpu5 dpu_control_plane_state up
+HSET DPU_STATE|dpu5 dpu_data_plane_state up
+HSET DPU_STATE|dpu6 dpu_midplane_link_state up
+HSET DPU_STATE|dpu6 dpu_control_plane_state up
+HSET DPU_STATE|dpu6 dpu_data_plane_state up
+HSET DPU_STATE|dpu7 dpu_midplane_link_state up
+HSET DPU_STATE|dpu7 dpu_control_plane_state up
+HSET DPU_STATE|dpu7 dpu_data_plane_state up
+
+select 4
+HSET DASH_BFD_PROBE_STATE|dpu0 v4_bfd_up_sessions "10.1.0.32"

--- a/test_utils/run_redis.sh
+++ b/test_utils/run_redis.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Check if both arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <database_config.json> <redis_data.cmd>"
+    exit 1
+fi
+
+# Access the arguments
+db_cfg="$1"
+db_data="$2"
+mkdir -p /var/run/redis/sonic-db
+cp $db_cfg /var/run/redis/sonic-db/
+redis-server --appendonly no --save --notify-keyspace-events AKE --port 6379 --unixsocket /var/run/redis/redis.sock&
+sleep 3
+redis-cli < $db_data


### PR DESCRIPTION
### why

Creating simulation environment for running hamgrd and relevant components from workspace. This can help development without using a physical smartswitch.

### What this PR does

Adding script to start redis-db and initialize it with data
Adding a README.md for instructions to run the supporting components for hamgrd.