### PR TITLE
Fix CI issues after upgrading to rustc 1.88.0

### DIFF
--- a/crates/container/src/container.rs
+++ b/crates/container/src/container.rs
@@ -93,7 +93,7 @@ impl<'a> Container<'a> {
                 "config file isn't an object at the top level".to_string(),
             ))?
             .get(field)
-            .ok_or(Error::JSONData(format!("field {} not found", field)))
+            .ok_or(Error::JSONData(format!("field {field} not found")))
             .cloned()
     }
 
@@ -104,7 +104,7 @@ impl<'a> Container<'a> {
             DB_FEATURE_TABLE
         };
 
-        let data = db_connector.hgetall(&format!("{}|{}", table_name, key))?;
+        let data = db_connector.hgetall(&format!("{table_name}|{key}"))?;
         for (field, default) in fields.iter_mut() {
             if let Some(value) = data.get(field as &str) {
                 *default = value.to_str()?.to_string()
@@ -153,7 +153,7 @@ impl<'a> Container<'a> {
         if self.db_connections.remote_ctr_enabled {
             self.db_connections.state_db.hset(
                 DB_KUBE_LABEL_TABLE,
-                &format!("{}|{}_enabled", DB_KUBE_LABEL_SET_KEY, feature),
+                &format!("{DB_KUBE_LABEL_SET_KEY}|{feature}_enabled"),
                 &CxxString::new(if create { "true" } else { "false" }),
             )?;
         }

--- a/crates/sonic-common/src/log.rs
+++ b/crates/sonic-common/src/log.rs
@@ -154,7 +154,7 @@ fn new_file_subscriber(
     use color_eyre::eyre::ContextCompat;
 
     let identity =
-        std::ffi::CString::new(program_name).wrap_err(format!("Unable to create syslog identity: {}", program_name))?;
+        std::ffi::CString::new(program_name).wrap_err(format!("Unable to create syslog identity: {program_name}"))?;
     let (options, facility) = Default::default();
     let syslog =
         syslog_tracing::Syslog::new(identity, options, facility).wrap_err("Unable to create syslog writer.")?;
@@ -173,7 +173,7 @@ pub fn init_logger_for_test() {
 
     let mut log_init_guard = LOG_FOR_TEST_INIT
         .lock()
-        .unwrap_or_else(|err| panic!("Failed to lock: {}", err));
+        .unwrap_or_else(|err| panic!("Failed to lock: {err}"));
     if *log_init_guard {
         return;
     }

--- a/crates/sonic-common/src/panic.rs
+++ b/crates/sonic-common/src/panic.rs
@@ -23,7 +23,7 @@ pub fn init(program_name: &'static str) -> Result<()> {
         tracing::error!("Error: {}", msg);
 
         #[cfg(not(debug_assertions))]
-        eprintln!("{}", msg);
+        eprintln!("{msg}");
 
         #[cfg(not(debug_assertions))]
         report_panic_as_dump(program_name, panic_info);

--- a/crates/swbus-actor/src/driver.rs
+++ b/crates/swbus-actor/src/driver.rs
@@ -125,7 +125,7 @@ impl<A: Actor> ActorDriver<A> {
                         body: MessageBody::Response {
                             request_id,
                             error_code: SwbusErrorCode::InvalidArgs,
-                            error_message: format!("Unsupported request type: {:?}", request),
+                            error_message: format!("Unsupported request type: {request:?}"),
                             response_body: None,
                         },
                     })

--- a/crates/swbus-actor/tests/test_executor.rs
+++ b/crates/swbus-actor/tests/test_executor.rs
@@ -130,14 +130,14 @@ async fn run_test(mut t: TestSpec) -> Option<&'static str> {
             name: s.clone(),
             db: redis.db_connector(),
             notify_done: notify_done.clone(),
-            spec: t.actors.remove(&s).expect(&format!("No actor in test json named {s}")),
+            spec: t.actors.remove(&s).expect("No actor in test json named {s}"),
             env: Environment::default(),
         };
 
         swbus_actor::spawn(actor, sp(&s));
     }
 
-    if let Err(_) = timeout(Duration::from_secs(5), recv_done.recv()).await {
+    if (timeout(Duration::from_secs(5), recv_done.recv()).await).is_err() {
         Some("test timed out")
     } else {
         None
@@ -226,7 +226,7 @@ impl Actor for TestActor {
         let handle_message_map = mem::take(&mut self.spec.handle_message);
         if let Some(actions) = handle_message_map.get(key).or_else(|| handle_message_map.get("*")) {
             for action in actions {
-                self.run_action(&action, state).await?;
+                self.run_action(action, state).await?;
             }
         }
         self.spec.handle_message = handle_message_map;

--- a/crates/swbus-cli/src/main.rs
+++ b/crates/swbus-cli/src/main.rs
@@ -128,7 +128,7 @@ fn get_swbus_config(config_file: Option<&str>) -> Result<SwbusConfig> {
     match config_file {
         Some(config_file) => {
             let config = swbus_config_from_yaml(config_file)
-                .context(format!("Failed to read swbusd config from file {}", config_file))?;
+                .context(format!("Failed to read swbusd config from file {config_file}"))?;
             Ok(config)
         }
         None => {
@@ -268,13 +268,13 @@ mod tests {
         // Mock the config database with a sample configuration
         populate_configdb_for_test();
 
-        std::env::set_var("DEV", format!("dpu{}", slot));
+        std::env::set_var("DEV", format!("dpu{slot}"));
         let config = get_swbus_config(None).unwrap();
         assert_eq!(config.endpoint.to_string(), format!("{}:{}", npu_ipv4, 23606 + slot));
         let expected_sp = ServicePath::with_node(
             "region-a",
             "cluster-a",
-            &format!("{}-dpu{}", npu_ipv4, slot),
+            &format!("{npu_ipv4}-dpu{slot}"),
             "",
             "",
             "",

--- a/crates/swbus-core/src/mux/conn.rs
+++ b/crates/swbus-core/src/mux/conn.rs
@@ -66,12 +66,8 @@ impl SwbusConn {
         mux: Arc<SwbusMultiplexer>,
         conn_store: Arc<SwbusConnStore>,
     ) -> Result<SwbusConn> {
-        let endpoint = Endpoint::from_str(&format!("http://{}", conn_info.remote_addr())).map_err(|e| {
-            SwbusError::input(
-                SwbusErrorCode::InvalidArgs,
-                format!("Failed to create endpoint: {}.", e),
-            )
-        })?;
+        let endpoint = Endpoint::from_str(&format!("http://{}", conn_info.remote_addr()))
+            .map_err(|e| SwbusError::input(SwbusErrorCode::InvalidArgs, format!("Failed to create endpoint: {e}.")))?;
 
         let channel = match endpoint.connect().await {
             Ok(c) => c,

--- a/crates/swbus-core/src/mux/conn_proxy.rs
+++ b/crates/swbus-core/src/mux/conn_proxy.rs
@@ -61,7 +61,7 @@ mod tests {
         if let SwbusError::RouteError { code, .. } = error {
             assert_eq!(code, SwbusErrorCode::QueueFull);
         } else {
-            panic!("Expected RouteError, got {:?}", error);
+            panic!("Expected RouteError, got {error:?}");
         }
     }
 }

--- a/crates/swbus-core/src/mux/nexthop.rs
+++ b/crates/swbus-core/src/mux/nexthop.rs
@@ -166,7 +166,7 @@ impl SwbusNextHop {
             }
             _ => Err(SwbusError::input(
                 SwbusErrorCode::InvalidArgs,
-                format!("Invalid management request: {:?}", mgmt_request),
+                format!("Invalid management request: {mgmt_request:?}"),
             )),
         }
     }

--- a/crates/swbus-core/src/mux/service.rs
+++ b/crates/swbus-core/src/mux/service.rs
@@ -89,7 +89,7 @@ impl SwbusServiceHost {
             .map_err(|e| {
                 SwbusError::connection(
                     SwbusErrorCode::ConnectionError,
-                    io::Error::other(format!("Failed to listen at {}: {}", addr, e)),
+                    io::Error::other(format!("Failed to listen at {addr}: {e}")),
                 )
             })?;
         debug!("SwbusServiceServer terminated");

--- a/crates/swbus-core/tests/common/test_executor.rs
+++ b/crates/swbus-core/tests/common/test_executor.rs
@@ -130,7 +130,7 @@ impl TopoRuntime {
     async fn start_client(&mut self, name: &str, node_addr: &SocketAddr, client_sp: ServicePath) {
         let (receive_queue_tx, receive_queue_rx) = mpsc::channel::<SwbusMessage>(2);
         let start = Instant::now();
-        let addr = format!("http://{}", node_addr);
+        let addr = format!("http://{node_addr}");
 
         while start.elapsed() < Duration::from_secs(10) {
             match SwbusCoreClient::connect(addr.clone(), client_sp.clone(), receive_queue_tx.clone()).await {
@@ -217,7 +217,7 @@ async fn receive_and_compare(topo: &mut TopoRuntime, expected_responses: &[Messa
                 panic!("channel broken");
             }
             Err(_) => {
-                panic!("timeout waiting for response: {:?}", resp);
+                panic!("timeout waiting for response: {resp:?}");
             }
         }
     }

--- a/crates/swbus-edge/src/core_client.rs
+++ b/crates/swbus-edge/src/core_client.rs
@@ -49,19 +49,15 @@ impl SwbusCoreClient {
     ) -> Result<(tokio::task::JoinHandle<Result<()>>, mpsc::Sender<SwbusMessage>)> {
         let (send_queue_tx, send_queue_rx) = mpsc::channel::<SwbusMessage>(100);
 
-        let endpoint = Endpoint::from_str(&uri).map_err(|e| {
-            SwbusError::input(
-                SwbusErrorCode::InvalidArgs,
-                format!("Failed to create endpoint: {}.", e),
-            )
-        })?;
+        let endpoint = Endpoint::from_str(&uri)
+            .map_err(|e| SwbusError::input(SwbusErrorCode::InvalidArgs, format!("Failed to create endpoint: {e}.")))?;
 
         let channel = match endpoint.connect().await {
             Ok(c) => c,
             Err(e) => {
                 return Err(SwbusError::connection(
                     SwbusErrorCode::ConnectionError,
-                    io::Error::new(io::ErrorKind::ConnectionReset, format!("Failed to connect: {:?}", e)),
+                    io::Error::new(io::ErrorKind::ConnectionReset, format!("Failed to connect: {e:?}")),
                 ));
             }
         };

--- a/crates/swbus-edge/src/edge_runtime.rs
+++ b/crates/swbus-edge/src/edge_runtime.rs
@@ -61,7 +61,7 @@ impl SwbusEdgeRuntime {
                 SwbusErrorCode::ConnectionError,
                 io::Error::new(
                     io::ErrorKind::ConnectionAborted,
-                    format!("Message router channel is broken: {}", e),
+                    format!("Message router channel is broken: {e}"),
                 ),
             )),
         }
@@ -94,13 +94,12 @@ mod tests {
 
         let config = format!(
             r#"
-        endpoint: "127.0.0.1:{}"
+        endpoint: "127.0.0.1:{port}"
         routes:
           - key: "region-a.cluster-a.10.0.1.0-dpu0"
             scope: "Cluster"
-        peers:        
-        "#,
-            port
+        peers:
+        "#
         );
         serde_yaml::from_str(&config).unwrap()
     }

--- a/crates/swbus-edge/src/message_handler_proxy.rs
+++ b/crates/swbus-edge/src/message_handler_proxy.rs
@@ -21,7 +21,7 @@ impl SwbusMessageHandlerProxy {
                 SwbusErrorCode::ConnectionError,
                 io::Error::new(
                     io::ErrorKind::ConnectionAborted,
-                    format!("Message handler channel is broken: {}", e),
+                    format!("Message handler channel is broken: {e}"),
                 ),
             )),
         }

--- a/crates/swbus-proto/src/swbus.rs
+++ b/crates/swbus-proto/src/swbus.rs
@@ -140,7 +140,7 @@ impl ServicePath {
         .join("/");
         match rsc_str.is_empty() {
             true => loc_str.to_string(),
-            false => format!("{}/{}", loc_str, rsc_str),
+            false => format!("{loc_str}/{rsc_str}"),
         }
     }
 
@@ -243,8 +243,7 @@ where
     match ServicePath::from_string(&s) {
         Ok(sp) => Ok(Some(sp)),
         Err(_) => Err(serde::de::Error::custom(format!(
-            "Failed to parse service path from string: {}",
-            s
+            "Failed to parse service path from string: {s}"
         ))),
     }
 }
@@ -259,8 +258,7 @@ where
     match ServicePath::from_string(&s) {
         Ok(sp) => Ok(sp),
         Err(_) => Err(serde::de::Error::custom(format!(
-            "Failed to parse service path from string: {}",
-            s
+            "Failed to parse service path from string: {s}"
         ))),
     }
 }

--- a/crates/swbusd/src/main.rs
+++ b/crates/swbusd/src/main.rs
@@ -21,7 +21,7 @@ async fn main() {
     let args = Args::parse();
 
     if let Err(e) = log::init("swbusd", true) {
-        eprintln!("Failed to initialize logging: {}", e);
+        eprintln!("Failed to initialize logging: {e}");
     }
     info!("Starting swbusd");
     let swbusd_config = match args.slot_id {

--- a/crates/swss-common-bridge/src/producer.rs
+++ b/crates/swss-common-bridge/src/producer.rs
@@ -163,7 +163,7 @@ mod test {
             let msg = OutgoingMessage {
                 destination: sp("mytable-bridge"),
                 body: MessageBody::Request {
-                    payload: encode_kfv(&kfv),
+                    payload: encode_kfv(kfv),
                 },
             };
             swbus.send(msg).await.unwrap();

--- a/crates/swss-common/src/types/logger.rs
+++ b/crates/swss-common/src/types/logger.rs
@@ -70,7 +70,7 @@ extern "C" fn priority_change_notify(_component: *const c_char, priority: *const
 
     logger.set_level(priority.to_string());
 
-    println!("Priority set to: {}", priority);
+    println!("Priority set to: {priority}");
 }
 
 extern "C" fn output_change_notify(_component: *const c_char, output: *const c_char) {
@@ -80,7 +80,7 @@ extern "C" fn output_change_notify(_component: *const c_char, output: *const c_c
     let mut logger = LOGGER.lock().unwrap();
     logger.handler.as_mut().unwrap().as_mut().on_log_output_change(output);
     logger.set_output(output.to_string());
-    println!("Output set to: {}", output);
+    println!("Output set to: {output}");
 }
 
 pub fn log_level() -> String {


### PR DESCRIPTION
### why
CI automatically download latest rustc. After rustc 1.88.0 is released, CI shows multiple lint issues.

### what this PR does
Addresses all the CI issues in rustc 1.88.0