### PR TITLE
Add test case to verify zmq reconnect behaviour

### DIFF
--- a/crates/hamgrd/src/actors.rs
+++ b/crates/hamgrd/src/actors.rs
@@ -16,8 +16,7 @@ use swbus_edge::swbus_proto::result::*;
 use swbus_edge::swbus_proto::swbus::{swbus_message::Body, DataRequest, ServicePath, SwbusErrorCode, SwbusMessage};
 use swbus_edge::SwbusEdgeRuntime;
 use swss_common::{
-    KeyOpFieldValues, KeyOperation, ProducerStateTable, SonicDbTable, SubscriberStateTable, ZmqClient,
-    ZmqProducerStateTable,
+    KeyOpFieldValues, KeyOperation, SonicDbTable, SubscriberStateTable, ZmqClient, ZmqProducerStateTable,
 };
 use swss_common_bridge::{consumer::ConsumerBridge, producer::spawn_producer_bridge};
 use tokio::sync::mpsc::{channel, Receiver};
@@ -276,18 +275,6 @@ where
         );
         Ok(spawn_producer_bridge(edge_runtime.clone(), sp, zpst))
     } else {
-        if std::env::var("SIM").is_err() {
-            anyhow::bail!("Failed to connect to ZMQ server at {}", zmq_endpoint);
-        }
-        let dpu_appl_db = crate::db_for_table::<T>().await?;
-        let pst = ProducerStateTable::new(dpu_appl_db, T::table_name()).unwrap();
-
-        let sp = crate::common_bridge_sp::<T>(&edge_runtime);
-        info!(
-            "spawned producer bridge for {} at {}",
-            T::table_name(),
-            sp.to_longest_path()
-        );
-        Ok(spawn_producer_bridge(edge_runtime.clone(), sp, pst))
+        anyhow::bail!("Failed to connect to ZMQ server at {}", zmq_endpoint);
     }
 }

--- a/test_utils/README.md
+++ b/test_utils/README.md
@@ -5,7 +5,7 @@ This folder contains some utilities, configurations, instructions on running man
 
     cd test_utils
     
-    ./run_redis.sh hamgrd/database_config.json hamgrd/redis_data_set.cmd 
+    ./run_redis.sh hamgrd/database_config.json hamgrd/database_global.json hamgrd/redis_data_set.cmd 
 
 - Start swbusd
 
@@ -18,3 +18,4 @@ This folder contains some utilities, configurations, instructions on running man
 - Run swbus-cli
 
     DEV=dpu0 target/debug/swbus-cli show hamgrd actor /hamgrd/0/dpu/switch1_dpu0
+


### PR DESCRIPTION
### why
During investigating issue #75, I created test case to verify zmq behaviour in handling no connection and connection loss. It is found that with the current swss-common zmq implementation with below attributes, we don't need to handle reconnect explicitly.

- PUSH/PULL model
- ZMQ_IMMEDIATE = 0 (default)
- ZMQ_SNDHWM = 10000

### what this PR does

- add unit test for zmq late connect and reconnect for regression
- remove unneeded code for falling back to ProducerStateTable in test environment since zmq client won't fail if zmq server is not connected.
- update test_utils/README.md with missing argument to start redis in test environment