### PR TITLE
Use vnet_name from DASH_HA_GLOBAL_CONFIG to create vnet route

### DIFF
--- a/crates/hamgrd/src/actors/ha_set.rs
+++ b/crates/hamgrd/src/actors/ha_set.rs
@@ -2,7 +2,7 @@ use crate::actors::vdpu::VDpuActor;
 use crate::actors::{spawn_consumer_bridge_for_actor, DbBasedActor};
 use crate::db_structs::*;
 use crate::ha_actor_messages::{ActorRegistration, HaSetActorState, RegistrationType, VDpuActorState};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use swbus_actor::{
     state::{incoming::Incoming, internal::Internal, outgoing::Outgoing},
     Actor, ActorMessage, Context, State,
@@ -43,10 +43,26 @@ struct VDpuStateExt {
 }
 
 impl HaSetActor {
-    fn get_dash_global_config(incoming: &Incoming) -> Result<DashHaGlobalConfig> {
-        let kfv: KeyOpFieldValues = incoming.get(DashHaGlobalConfig::table_name())?.deserialize_data()?;
-        let global_cfg = swss_serde::from_field_values(&kfv.field_values)?;
-        Ok(global_cfg)
+    fn get_dash_global_config(incoming: &Incoming) -> Option<DashHaGlobalConfig> {
+        let Ok(msg) = incoming.get(DashHaGlobalConfig::table_name()) else {
+            debug!("DASH_HA_GLOBAL_CONFIG table is not available");
+            return None;
+        };
+        let kfv = match msg.deserialize_data::<KeyOpFieldValues>() {
+            Ok(data) => data,
+            Err(e) => {
+                error!("Failed to deserialize DASH_HA_GLOBAL_CONFIG KeyOpFieldValues: {}", e);
+                return None;
+            }
+        };
+
+        match swss_serde::from_field_values(&kfv.field_values) {
+            Ok(state) => Some(state),
+            Err(e) => {
+                error!("Failed to deserialize DASH_HA_GLOBAL_CONFIG from field values: {}", e);
+                None
+            }
+        }
     }
 
     fn prepare_dash_ha_set_table_data(
@@ -73,7 +89,9 @@ impl HaSetActor {
             }
         };
 
-        let global_cfg = Self::get_dash_global_config(incoming)?;
+        let Some(global_cfg) = Self::get_dash_global_config(incoming) else {
+            return Ok(None);
+        };
 
         let dash_ha_set = DashHaSetTable {
             version: dash_ha_set_config.version.clone(),
@@ -121,13 +139,29 @@ impl HaSetActor {
         Ok(())
     }
 
-    fn update_vnet_route_tunnel_table(
+    async fn update_vnet_route_tunnel_table(
         &self,
         vdpus: &Vec<VDpuStateExt>,
         incoming: &Incoming,
         internal: &mut Internal,
     ) -> Result<()> {
-        let global_cfg = Self::get_dash_global_config(incoming)?;
+        let Some(global_cfg) = Self::get_dash_global_config(incoming) else {
+            return Ok(());
+        };
+
+        let swss_key = format!(
+            "{}:{}",
+            global_cfg
+                .vnet_name
+                .ok_or(anyhow!("Missing vnet_name in global config"))?,
+            self.dash_ha_set_config.as_ref().unwrap().vip_v4
+        );
+
+        if !internal.has_entry(VnetRouteTunnelTable::table_name(), &swss_key) {
+            let db = crate::db_for_table::<VnetRouteTunnelTable>().await?;
+            let table = Table::new_async(db, VnetRouteTunnelTable::table_name()).await?;
+            internal.add(VnetRouteTunnelTable::table_name(), table, swss_key).await;
+        }
 
         let mut endpoint = Vec::new();
         let mut endpoint_monitor = Vec::new();
@@ -246,7 +280,7 @@ impl HaSetActor {
         key: &str,
         context: &mut Context,
     ) -> Result<()> {
-        let (internal, incoming, outgoing) = state.get_all();
+        let (_internal, incoming, outgoing) = state.get_all();
         let dpu_kfv: KeyOpFieldValues = incoming.get(key)?.deserialize_data()?;
         if dpu_kfv.operation == KeyOperation::Del {
             // unregister from the DPU Actor
@@ -258,12 +292,7 @@ impl HaSetActor {
         let first_time = self.dash_ha_set_config.is_none();
 
         self.dash_ha_set_config = Some(swss_serde::from_field_values(&dpu_kfv.field_values)?);
-        let swss_key = format!("default:{}", self.dash_ha_set_config.as_ref().unwrap().vip_v4);
-        if !internal.has_entry(VnetRouteTunnelTable::table_name(), &swss_key) {
-            let db = crate::db_for_table::<VnetRouteTunnelTable>().await?;
-            let table = Table::new_async(db, VnetRouteTunnelTable::table_name()).await?;
-            internal.add(VnetRouteTunnelTable::table_name(), table, swss_key).await;
-        }
+
         // Subscribe to the DPU Actor for state updates.
         self.register_to_vdpu_actor(outgoing, true).await?;
 
@@ -288,25 +317,25 @@ impl HaSetActor {
         Ok(())
     }
 
-    fn handle_dash_ha_global_config(&mut self, state: &mut State) -> Result<()> {
+    async fn handle_dash_ha_global_config(&mut self, state: &mut State) -> Result<()> {
         let (internal, incoming, outgoing) = state.get_all();
         let Some(vdpus) = self.get_vdpus_if_ready(incoming) else {
             return Ok(());
         };
         // global config update affects Vxlan tunnel and dash-ha-set in DPU
         self.update_dash_ha_set_table(&vdpus, incoming, outgoing)?;
-        self.update_vnet_route_tunnel_table(&vdpus, incoming, internal)?;
+        self.update_vnet_route_tunnel_table(&vdpus, incoming, internal).await?;
         Ok(())
     }
 
-    fn handle_vdpu_state_update(&mut self, state: &mut State) -> Result<()> {
+    async fn handle_vdpu_state_update(&mut self, state: &mut State) -> Result<()> {
         let (internal, incoming, outgoing) = state.get_all();
         // vdpu update affects dash-ha-set in DPU and vxlan tunnel
         let Some(vdpus) = self.get_vdpus_if_ready(incoming) else {
             return Ok(());
         };
         self.update_dash_ha_set_table(&vdpus, incoming, outgoing)?;
-        self.update_vnet_route_tunnel_table(&vdpus, incoming, internal)?;
+        self.update_vnet_route_tunnel_table(&vdpus, incoming, internal).await?;
         Ok(())
     }
 
@@ -346,9 +375,9 @@ impl Actor for HaSetActor {
         }
 
         if VDpuActorState::is_my_msg(key) {
-            return self.handle_vdpu_state_update(state);
+            return self.handle_vdpu_state_update(state).await;
         } else if key == DashHaGlobalConfig::table_name() {
-            return self.handle_dash_ha_global_config(state);
+            return self.handle_dash_ha_global_config(state).await;
         } else if ActorRegistration::is_my_msg(key, RegistrationType::HaSetState) {
             return self.handle_haset_state_registration(state, key).await;
         }
@@ -444,7 +473,7 @@ mod test {
             // Verify that haset actor state is sent to ha-scope actor
             recv! { key: HaSetActorState::msg_key(&ha_set_id), data: { "up": true, "ha_set": &ha_set_obj },
                     addr: runtime.sp("ha-scope", &format!("vdpu0:{ha_set_id}")) },
-            chkdb! { type: VnetRouteTunnelTable, key: &format!("default:{}", ha_set_cfg.vip_v4), data: expected_vnet_route },
+            chkdb! { type: VnetRouteTunnelTable, key: &format!("{}:{}", global_cfg.vnet_name.unwrap(), ha_set_cfg.vip_v4), data: expected_vnet_route },
             // simulate delete of ha-set entry
             send! { key: HaSetActor::table_name(), data: { "key": HaSetActor::table_name(), "operation": "Del", "field_values": ha_set_cfg_fvs },
                     addr: crate::common_bridge_sp::<DashHaSetConfigTable>(&runtime.get_swbus_edge()) },
@@ -517,7 +546,7 @@ mod test {
             // Simulate VDPU state update for vdpu1 (backup)
             send! { key: VDpuActorState::msg_key(&vdpu1_id), data: vdpu1_state, addr: runtime.sp("vdpu", &vdpu1_id) },
             // Verify that the DASH_HA_SET_TABLE was updated
-            chkdb! { type: VnetRouteTunnelTable, key: &format!("default:{}", ha_set_cfg.vip_v4),
+            chkdb! { type: VnetRouteTunnelTable, key: &format!("{}:{}", global_cfg.vnet_name.unwrap(), ha_set_cfg.vip_v4),
                     data: expected_vnet_route },
             // simulate delete of ha-set entry
             send! { key: HaSetActor::table_name(), data: { "key": HaSetActor::table_name(), "operation": "Del", "field_values": ha_set_cfg_fvs },

--- a/crates/hamgrd/src/db_structs.rs
+++ b/crates/hamgrd/src/db_structs.rs
@@ -29,6 +29,8 @@ pub struct DashHaGlobalConfig {
     pub dpu_bfd_probe_interval_in_ms: Option<u32>,
     // The number of DPU BFD probe failure before probe down.
     pub dpu_bfd_probe_multiplier: Option<u32>,
+    // The name of the vnet used for VNET tunnel route
+    pub vnet_name: Option<String>,
 }
 
 /// <https://github.com/sonic-net/SONiC/blob/master/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md#2111-dpu--vdpu-definitions>

--- a/crates/swbus-actor/src/driver.rs
+++ b/crates/swbus-actor/src/driver.rs
@@ -5,7 +5,7 @@ use swbus_edge::{
     simple_client::{IncomingMessage, MessageBody, MessageResponseBody, OutgoingMessage, SimpleSwbusEdgeClient},
     swbus_proto::swbus::{ManagementRequestType, ServicePath, SwbusErrorCode},
 };
-use tracing::{debug, info, instrument};
+use tracing::{debug, error, info, instrument};
 
 /// An actor and the support structures needed to run it.
 pub(crate) struct ActorDriver<A> {
@@ -116,12 +116,13 @@ impl<A: Actor> ActorDriver<A> {
                 (SwbusErrorCode::Ok, String::new())
             }
             Err(e) => {
+                error!("Actor failed to handle message: {e:#}");
                 self.state.internal.drop_changes();
                 self.state.outgoing.drop_queued_messages();
                 (SwbusErrorCode::Fail, format!("{e:#}"))
             }
         };
-        debug!("message handled by actor: {error_code:?} {error_message}");
+        info!("message handled by actor: {error_code:?} {error_message}");
         self.state.incoming.request_handled(key, error_code, &error_message);
     }
 

--- a/test_utils/hamgrd/redis_data_set.cmd
+++ b/test_utils/hamgrd/redis_data_set.cmd
@@ -40,6 +40,7 @@ HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_src_port_min" "7001"
 HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_src_port_max" "7010"
 HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_probe_interval_ms" "500"
 HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dp_channel_probe_fail_threshold" "5"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "vnet_name" "Vnet55"
 
 select 13
 HSET DPU_STATE|dpu0 dpu_midplane_link_state up

--- a/test_utils/hamgrd/redis_data_set_full.cmd
+++ b/test_utils/hamgrd/redis_data_set_full.cmd
@@ -105,6 +105,7 @@ HSET "REMOTE_DPU|switch3_dpu0" "swbus_port" "23606"
 
 HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_interval_in_ms" "1000"
 HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "dpu_bfd_probe_multiplier" "3"
+HSET "DASH_HA_GLOBAL_CONFIG|GLOBAL" "vnet_name" "Vnet55"
 
 
 select 13


### PR DESCRIPTION
### why
Previously it is hardcoded to default when creating vxlan vnet route from ha_set actor.

### what this PR does

1. get vnet_name from dash_ha_global_config
2. Move creating VnetRouteTunnelTable internal entry from handle_dash_ha_set_config_table_message to update_vnet_route_tunnel_table because dash_ha_global_config is not received yet.
3. Add retry to chkdb because the previous 'send' operation may not be processed yet.