### PR TITLE
Set ha_set_id in DASH_HA_SCOPE_TABLE

### DIFF
--- a/crates/hamgrd/src/actors/ha_scope.rs
+++ b/crates/hamgrd/src/actors/ha_scope.rs
@@ -274,10 +274,7 @@ impl HaScopeActor {
         let pmon_state = vdpu.dpu.dpu_pmon_state.unwrap_or_default();
         let bfd_state = vdpu.dpu.dpu_bfd_state.unwrap_or_default();
 
-        let Some(ha_set_id) = self.get_haset_id() else {
-            debug!("HA set ID is not available. Skip DASH_HA_SCOPE_STATE update");
-            return Ok(());
-        };
+        let ha_set_id = self.get_haset_id().unwrap();
 
         let Some(haset) = self.get_haset(incoming) else {
             debug!(

--- a/crates/hamgrd/src/actors/ha_set.rs
+++ b/crates/hamgrd/src/actors/ha_set.rs
@@ -101,6 +101,7 @@ impl HaSetActor {
             version: dash_ha_set_config.version.clone(),
             vip_v4: dash_ha_set_config.vip_v4.as_ref().map(ip_to_string).unwrap_or_default(),
             vip_v6: dash_ha_set_config.vip_v6.as_ref().map(ip_to_string),
+            owner: None,
             scope: sonic_dash_api_proto::types::HaScope::try_from(dash_ha_set_config.scope)
                 .map(|s| {
                     let name = s.as_str_name();

--- a/crates/hamgrd/src/actors/test.rs
+++ b/crates/hamgrd/src/actors/test.rs
@@ -482,6 +482,7 @@ pub fn make_dpu_scope_ha_set_obj(switch: u16, dpu: u16) -> (String, DashHaSetTab
         version: "1".to_string(),
         vip_v4: ip_to_string(&haset_cfg.vip_v4.unwrap()),
         vip_v6: Some(ip_to_string(&haset_cfg.vip_v6.unwrap())),
+        owner: None,
         scope: Some("ha_scope_dpu".to_string()),
         local_npu_ip: format!("10.0.{switch}.{dpu}"),
         local_ip: format!("18.0.{switch}.{dpu}"),

--- a/crates/hamgrd/src/db_structs.rs
+++ b/crates/hamgrd/src/db_structs.rs
@@ -229,6 +229,8 @@ pub struct DashHaSetTable {
     pub vip_v4: String,
     // IPv4 Data path VIP.
     pub vip_v6: Option<String>,
+    // Owner of HA state machine. It can be dpu or switch.
+    pub owner: Option<String>,
     // Scope of HA set. It can be dpu, eni.
     pub scope: Option<String>,
     // The IP address of local NPU. It can be IPv4 or IPv6. Used for setting up the BFD session.
@@ -283,6 +285,7 @@ pub struct DashHaScopeTable {
     pub version: u32,
     pub disabled: bool,
     pub ha_role: String,
+    pub ha_set_id: String,
     pub flow_reconcile_requested: bool,
     pub activate_role_requested: bool,
 }


### PR DESCRIPTION
### why
ha_set_id is added to DASH_HA_SCOPE_TABLE. hamgrd needs to pass ha_set_id in DASH_HA_SCOPE_CONFIG_TABLE

### what this PR does

- passes ha_set_id in DASH_HA_SCOPE_CONFIG_TABLE to DASH_HA_SCOPE_TABLE
- we used to extract ha-set id from key of DASH_HA_SCOPE_CONFIG_TABLE. Since ha_set_id is a field in the table, we don't need to extract it from the key
- add owner to DASH_HA_SET_TABLE according to HLD but the field is not set since dashhaorch is not using it
