### PR TITLE
Add vip_v4 and vip_v6 to DPU DASH_HA_SCOPE_TABLE

### DIFF
--- a/crates/hamgrd/src/db_structs.rs
+++ b/crates/hamgrd/src/db_structs.rs
@@ -286,6 +286,8 @@ pub struct DashHaScopeTable {
     pub disabled: bool,
     pub ha_role: String,
     pub ha_set_id: String,
+    pub vip_v4: String,
+    pub vip_v6: Option<String>,
     pub flow_reconcile_requested: bool,
     pub activate_role_requested: bool,
 }


### PR DESCRIPTION
### why
There is a mismatch between DASH_HA_SCOPE_TABLE in DPU sonic-db and SAI HA_SCOPE definition. vip_v4 and vip_v6 exist in the latter but not in DASH_HA_SCOPE_TABLE. DashHaOrch has to implement complicated logic to get vip_v4 and vip_v6 from DASH_HA_SET_TABLE. To simplify DashHaOrch design, vip_v4 and vip_v6 are added to DASH_HA_SCOPE_TABLE. Accordingly, hamgrd needs to adapt to it.

### what this PR does
1. Update DASH_HA_SCOPE_TABLE until it receives DASH_HA_SET_CONFIG from corresponding ha_set actor
2. Copy vip_v4 and vip_v6 from DASH_HA_SET_CONFIG to DASH_HA_SCOPE_TABLE
3. Update UT