### PR TITLE
Update sonic_db_config_initialize_global with extra argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "swss-common"
 version = "0.1.0"
-source = "git+https://github.com/sonic-net/sonic-swss-common.git?branch=master#93af9275a3c413b45a47e4fd7967f15e2ea13297"
+source = "git+https://github.com/sonic-net/sonic-swss-common.git?branch=master#1484a851dbfdd4b122c361cd7ea03eca0afe5d63"
 dependencies = [
  "bindgen",
  "getset",
@@ -2178,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "swss-common-testing"
 version = "0.1.0"
-source = "git+https://github.com/sonic-net/sonic-swss-common.git?branch=master#93af9275a3c413b45a47e4fd7967f15e2ea13297"
+source = "git+https://github.com/sonic-net/sonic-swss-common.git?branch=master#1484a851dbfdd4b122c361cd7ea03eca0afe5d63"
 dependencies = [
  "lazy_static",
  "rand",

--- a/crates/container/src/container.rs
+++ b/crates/container/src/container.rs
@@ -113,7 +113,7 @@ impl<'a> Container<'a> {
         Ok(())
     }
 
-    pub fn new(feature: &str) -> Container {
+    pub fn new(feature: &str) -> Container<'_> {
         Container {
             feature,
             db_connections: DbConnections::initialize_connection(),

--- a/crates/hamgrd/src/actors.rs
+++ b/crates/hamgrd/src/actors.rs
@@ -217,8 +217,8 @@ where
 
     let addr = crate::common_bridge_sp::<T>(&edge_runtime);
 
-    if actor_id.is_some() {
-        let sp = edge_runtime.new_sp(actor_name, actor_id.unwrap());
+    if let Some(actor_id) = actor_id {
+        let sp = edge_runtime.new_sp(actor_name, actor_id);
         Ok(ConsumerBridge::spawn::<T, _, _, _>(
             edge_runtime,
             addr,

--- a/crates/hamgrd/src/main.rs
+++ b/crates/hamgrd/src/main.rs
@@ -45,7 +45,7 @@ async fn main() {
     }
 
     set_dpu_slot_id(args.slot_id as u8);
-    sonic_db_config_initialize_global("/var/run/redis/sonic-db/database_global.json").unwrap();
+    sonic_db_config_initialize_global("/var/run/redis/sonic-db/database_global.json", true).unwrap();
 
     // Read swbusd config from redis or yaml file
     let swbus_config = swbus_config_from_db(args.slot_id).unwrap();


### PR DESCRIPTION
### why
swss-common sonic_db_config_initialize_global introduced ignore_nonexistent argument. dash-ha code needs to adjust accordingly

### what this PR does
Add ignore_nonexistent when calling sonic_db_config_initialize_global