### PR TITLE
Implement mark-delete in actor framework

### DIFF
--- a/crates/hamgrd/src/actors/ha_scope.rs
+++ b/crates/hamgrd/src/actors/ha_scope.rs
@@ -817,7 +817,8 @@ mod test {
                         "flow_reconcile_requested": "false"
                     },
                     },
-                    addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge()) },
+                    addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())
+                },
 
             // Write to NPU DASH_HA_SCOPE_STATE through internal state with no pending activation
             chkdb! { type: NpuDashHaScopeState,
@@ -836,7 +837,23 @@ mod test {
 
             // Send vdpu state update after bfd session up
             send! { key: VDpuActorState::msg_key(&vdpu0_id), data: vdpu0_state_obj, addr: runtime.sp("vdpu", &vdpu0_id) },
-
+            // Recv update to DPU DASH_HA_SCOPE_TABLE, triggered by vdpu state update
+            recv! { key: &ha_set_id, data: {
+                    "key": &ha_set_id,
+                    "operation": "Set",
+                    "field_values": {
+                        "version": "3",
+                        "ha_role": "active",
+                        "disabled": "false",
+                        "ha_set_id": &ha_set_id,
+                        "vip_v4": ha_set_obj.vip_v4.clone(),
+                        "vip_v6": ha_set_obj.vip_v6.clone(),
+                        "activate_role_requested": "false",
+                        "flow_reconcile_requested": "false"
+                    },
+                    },
+                    addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())
+                },
             // Write to NPU DASH_HA_SCOPE_STATE through internal state with bfd session up
             chkdb! { type: NpuDashHaScopeState,
                     key: &scope_id_in_state, data: npu_ha_scope_state_fvs6,
@@ -853,10 +870,26 @@ mod test {
         let commands = [
             // Send DASH_HA_SCOPE_CONFIG_TABLE with desired_ha_state = dead
             send! { key: HaScopeConfig::table_name(), data: { "key": &scope_id, "operation": "Set",
-                    "field_values": {"json": format!(r#"{{"version":"2","disabled":false,"desired_ha_state":{},"owner":{},"ha_set_id":"{ha_set_id}","approved_pending_operation_ids":[]}}"#, DesiredHaState::Dead as i32, HaOwner::Dpu as i32)},
+                    "field_values": {"json": format!(r#"{{"version":"4","disabled":false,"desired_ha_state":{},"owner":{},"ha_set_id":"{ha_set_id}","approved_pending_operation_ids":[]}}"#, DesiredHaState::Dead as i32, HaOwner::Dpu as i32)},
                     },
                     addr: crate::common_bridge_sp::<HaScopeConfig>(&runtime.get_swbus_edge()) },
 
+            recv! { key: &ha_set_id, data: {
+                    "key": &ha_set_id,
+                    "operation": "Set",
+                    "field_values": {
+                        "version": "4",
+                        "ha_role": "dead",
+                        "disabled": "false",
+                        "ha_set_id": &ha_set_id,
+                        "vip_v4": ha_set_obj.vip_v4.clone(),
+                        "vip_v6": ha_set_obj.vip_v6.clone(),
+                        "activate_role_requested": "false",
+                        "flow_reconcile_requested": "false"
+                    },
+                    },
+                    addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())
+                },
             // Check NPU DASH_HA_SCOPE_STATE is updated with desired_ha_state = dead
             chkdb! { type: NpuDashHaScopeState,
                     key: &scope_id_in_state, data: npu_ha_scope_state_fvs7,
@@ -867,6 +900,8 @@ mod test {
                     "field_values": {"json": format!(r#"{{"version":"2","disabled":false,"desired_ha_state":{},"owner":{},"ha_set_id":"{ha_set_id}","approved_pending_operation_ids":[]}}"#, DesiredHaState::Dead as i32, HaOwner::Dpu as i32)},
                     },
                     addr: crate::common_bridge_sp::<HaScopeConfig>(&runtime.get_swbus_edge()) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &scope_id), data: { "active": false }, addr: runtime.sp(VDpuActor::name(), &vdpu0_id) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::HaSetState, &scope_id), data: { "active": false }, addr: runtime.sp(HaSetActor::name(), &ha_set_id) },
         ];
 
         test::run_commands(&runtime, runtime.sp(HaScopeActor::name(), &scope_id), &commands).await;

--- a/crates/hamgrd/src/actors/ha_set.rs
+++ b/crates/hamgrd/src/actors/ha_set.rs
@@ -516,6 +516,10 @@ mod test {
             // simulate delete of ha-set entry
             send! { key: HaSetActor::table_name(), data: { "key": HaSetActor::table_name(), "operation": "Del", "field_values": ha_set_cfg_fvs },
                     addr: crate::common_bridge_sp::<HaSetConfig>(&runtime.get_swbus_edge()) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &ha_set_id), data: { "active": false },
+                    addr: runtime.sp(VDpuActor::name(), &vdpu0_id) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &ha_set_id), data: { "active": false },
+                    addr: runtime.sp(VDpuActor::name(), &vdpu1_id) },
         ];
 
         test::run_commands(&runtime, runtime.sp(HaSetActor::name(), &ha_set_id), &commands).await;
@@ -591,6 +595,10 @@ mod test {
             // simulate delete of ha-set entry
             send! { key: HaSetActor::table_name(), data: { "key": HaSetActor::table_name(), "operation": "Del", "field_values": ha_set_cfg_fvs },
                     addr: crate::common_bridge_sp::<HaSetConfig>(&runtime.get_swbus_edge()) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &ha_set_id), data: { "active": false },
+                    addr: runtime.sp(VDpuActor::name(), &vdpu0_id) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &ha_set_id), data: { "active": false },
+                    addr: runtime.sp(VDpuActor::name(), &vdpu1_id) },
         ];
 
         test::run_commands(&runtime, runtime.sp(HaSetActor::name(), &ha_set_id), &commands).await;

--- a/crates/hamgrd/src/actors/vdpu.rs
+++ b/crates/hamgrd/src/actors/vdpu.rs
@@ -192,7 +192,8 @@ mod test {
 
             send! { key: VDpuActor::table_name(), data: { "key": VDpuActor::table_name(), "operation": "Del", "field_values": {"main_dpu_ids": "switch1_dpu0"}},
                     addr: crate::common_bridge_sp::<VDpu>(&runtime.get_swbus_edge()) },
-
+            recv! { key: ActorRegistration::msg_key(RegistrationType::DPUState, "test-vdpu"), data: { "active": false },
+                    addr: runtime.sp(DpuActor::name(), "switch1_dpu0") },
         ];
 
         test::run_commands(&runtime, runtime.sp(VDpuActor::name(), "test-vdpu"), &commands).await;

--- a/crates/swbus-actor/src/driver.rs
+++ b/crates/swbus-actor/src/driver.rs
@@ -13,6 +13,7 @@ pub(crate) struct ActorDriver<A> {
     state: State,
     swbus_edge: Arc<SimpleSwbusEdgeClient>,
     context: Context,
+    mark_deleted: bool,
 }
 
 impl<A: Actor> ActorDriver<A> {
@@ -24,7 +25,13 @@ impl<A: Actor> ActorDriver<A> {
             state: State::new(swbus_edge.clone()),
             swbus_edge,
             context: Context::new(edge_runtime),
+            mark_deleted: false,
         }
+    }
+
+    /// Check if the actor is ready for deletion (no unacked messages)
+    fn ready_for_delete(&self) -> bool {
+        self.state.outgoing.ready_for_delete()
     }
 
     /// Run the actor's main loop
@@ -46,11 +53,21 @@ impl<A: Actor> ActorDriver<A> {
                 }
             }
             if self.context.stopped {
-                info!(
-                    "actor {} terminated",
-                    self.swbus_edge.get_service_path().to_longest_path()
-                );
-                break;
+                self.mark_deleted = true;
+            }
+            if self.mark_deleted {
+                if self.ready_for_delete() {
+                    info!(
+                        "actor {} terminated",
+                        self.swbus_edge.get_service_path().to_longest_path()
+                    );
+                    break;
+                } else {
+                    debug!(
+                        "actor {} marked for deletion, waiting for unacked messages to complete",
+                        self.swbus_edge.get_service_path().to_longest_path()
+                    );
+                }
             }
         }
     }
@@ -60,6 +77,24 @@ impl<A: Actor> ActorDriver<A> {
         let IncomingMessage { id, source, body, .. } = msg;
         match body {
             MessageBody::Request { payload } => {
+                if self.mark_deleted {
+                    // Actor is marked for deletion, send OK response but don't process
+                    debug!("Actor marked for deletion, skipping request processing");
+                    self.swbus_edge
+                        .send(OutgoingMessage {
+                            destination: source.clone(),
+                            body: MessageBody::Response {
+                                request_id: id,
+                                error_code: SwbusErrorCode::Ok,
+                                error_message: String::new(),
+                                response_body: None,
+                            },
+                        })
+                        .await
+                        .expect("failed to send swbus message");
+                    return;
+                }
+
                 let Ok(actor_msg) = ActorMessage::deserialize(&payload) else {
                     eprintln!("Received invalid actor message from {source}");
                     return;


### PR DESCRIPTION
### why
actor has the retry logic in outgoing state. If a message is not acked, it will resend the message to make sure receiver has received it successfully. When an actor is terminated, the retry will be terminated as well so it can't guarantee the receiver getting the message.

### what this PR does
Introduce mark-delete concept. 
1. when an actor is going to terminate, add "mark_deleted" flag to the driver of the actor. 
2. In the run loop of the actor, which is triggered each time it receives a message, it will check if the actor is ready_for_delete.
3. ready_for_delete checks if there is unacked message in outgoing state. Only exits from the run loop when there is non
4. When an actor is in mark_deleted state, stop processing incoming requests but always replies OK. So 2 mark_deleted actors won't form a dead loop.
5. response is processed normally so unacked messages can be ACKed.
6. management_request is processed normally so we can still dump actor state using swbus-cli