### PR TITLE
Fix producer bridge CI issue

### DIFF
--- a/crates/swss-common-bridge/src/producer.rs
+++ b/crates/swss-common-bridge/src/producer.rs
@@ -268,10 +268,12 @@ mod test {
         if result.is_ok() {
             // If we got here, it means the bridge did not skip the updates
             let received = consumer_table.pops().await;
-            for kfv in received {
-                println!("Received: {}", kfv.key);
+            if !received.is_empty() {
+                for kfv in received {
+                    println!("Received: {}", kfv.key);
+                }
+                panic!("Expected bridge to skip duplicate updates, but it processed them");
             }
-            panic!("Expected bridge to skip duplicate updates, but it processed them");
         }
     }
 


### PR DESCRIPTION
### why
producer_state_table_bridge_check_dup test failed. Suspect swss-common behaviour changed. 

### what this PR does
Make the check more strict to make sure no entries are received from consumer.