### PR TITLE
fix show hamgrd actor command

### DIFF
--- a/crates/swbus-core/src/mux/conn_worker.rs
+++ b/crates/swbus-core/src/mux/conn_worker.rs
@@ -152,9 +152,16 @@ where
                 debug!("Received route announcement");
                 self.mux.process_route_announcement(route_entries, &self.info)?;
             }
-            Some(swbus_message::Body::ManagementRequest(mgmt_request)) => {
-                let response = self.process_mgmt_request(message.header.as_ref().unwrap(), mgmt_request)?;
-                self.mux.route_message(response).await?;
+            Some(swbus_message::Body::ManagementRequest(ref mgmt_request)) => {
+                let my_sp = self.mux.get_my_service_path();
+                if message.header.as_ref().unwrap().destination.as_ref().unwrap() == my_sp {
+                    // Message is destined for this service, process it locally
+                    let response = self.process_mgmt_request(message.header.as_ref().unwrap(), mgmt_request.clone())?;
+                    self.mux.route_message(response).await?;
+                } else {
+                    // Message is not for us, route it to the intended destination
+                    self.mux.route_message(message).await?;
+                }
             }
             _ => {
                 self.mux.route_message(message).await?;

--- a/crates/swbus-core/tests/basic_tests.rs
+++ b/crates/swbus-core/tests/basic_tests.rs
@@ -1,15 +1,9 @@
 mod common;
-use common::test_executor::{init_logger, run_tests, TopoRuntime};
-
+use common::test_executor::{run_tests, TopoRuntime};
+use sonic_common::log::init_logger_for_test;
 #[tokio::test]
 async fn test_b2b() {
-    let trace_enabled: bool = std::env::var("ENABLE_TRACE")
-        .map(|val| val == "1" || val.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-
-    if trace_enabled {
-        init_logger();
-    }
+    init_logger_for_test();
 
     let mut topo = TopoRuntime::new("tests/data/b2b/topo.json");
     topo.bring_up().await;

--- a/crates/swbus-core/tests/common/test_executor.rs
+++ b/crates/swbus-core/tests/common/test_executor.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use sonic_common::log::init_logger_for_test;
 use std::collections::HashMap;
 use std::env;
 use std::fs::{self, File};
@@ -12,7 +11,6 @@ use swbus_proto::swbus::*;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::{self, Duration, Instant};
-use tracing_subscriber::{fmt, prelude::*, Layer};
 
 // 3 seconds receive timeout
 pub const RECEIVE_TIMEOUT: u32 = 3;
@@ -82,8 +80,6 @@ impl TopoRuntime {
     /// The client configurations are a map of client names to the client configuration.
     /// The client configuration contains the server (swbusd) name where the client is connected and the service path of the client.
     pub async fn bring_up(&mut self) {
-        init_logger_for_test();
-
         let file = File::open(&self.topo_file).unwrap();
         let reader = BufReader::new(file);
 
@@ -249,29 +245,4 @@ async fn record_received_messages(topo: &mut TopoRuntime, timeout: u32) -> Vec<M
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
     responses
-}
-
-pub fn init_logger() {
-    let stdout_level = tracing::level_filters::LevelFilter::DEBUG;
-    // Create a stdout logger for `info!` and lower severity levels
-    let stdout_layer = fmt::layer()
-        .with_writer(std::io::stdout)
-        .without_time()
-        .with_target(false)
-        .with_level(false)
-        .with_filter(stdout_level);
-
-    // Create a stderr logger for `error!` and higher severity levels
-    let stderr_layer = fmt::layer()
-        .with_writer(std::io::stderr)
-        .without_time()
-        .with_target(false)
-        .with_level(false)
-        .with_filter(tracing::level_filters::LevelFilter::ERROR);
-
-    // Combine the layers and set them as the global subscriber
-    tracing_subscriber::registry()
-        .with(stdout_layer)
-        .with(stderr_layer)
-        .init();
 }

--- a/crates/swbus-core/tests/data/inter-cluster/test_show_route.json
+++ b/crates/swbus-core/tests/data/inter-cluster/test_show_route.json
@@ -13,7 +13,7 @@
                 "flag": 0,
                 "ttl": 1,
                 "source": "region-a.cluster-a.node1/testsvc/0",
-                "destination": "region-a.cluster-b.node1"
+                "destination": "region-a.cluster-a.node1"
               },
               "body": {
                 "ManagementRequest": {

--- a/crates/swbus-core/tests/inter_cluster_tests.rs
+++ b/crates/swbus-core/tests/inter_cluster_tests.rs
@@ -1,15 +1,9 @@
 mod common;
-use common::test_executor::{init_logger, run_tests, TopoRuntime};
-
+use common::test_executor::{run_tests, TopoRuntime};
+use sonic_common::log::init_logger_for_test;
 #[tokio::test]
 async fn test_inter_cluster() {
-    let trace_enabled: bool = std::env::var("ENABLE_TRACE")
-        .map(|val| val == "1" || val.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-
-    if trace_enabled {
-        init_logger();
-    }
+    init_logger_for_test();
 
     let mut topo = TopoRuntime::new("tests/data/inter-cluster/topo.json");
     topo.bring_up().await;


### PR DESCRIPTION
### why
show hamgrd actor command is broken after route_exchange PR is merged. In log we can see this below error
Sep  5 12:11:25 ott-ss-010 swbusd: 2025-09-05T16:11:25.820184Z ERROR ConnWorker{conn_id="swbs-from://127.0.0.1:39642"}: 96: Failed to process the incoming message: Input:InvalidArgs - Invalid management request: ManagementRequest { request: HamgrdGetActorState, arguments: [] }

This is because swbusd incorrectly intercepting all ManagementRequest.
### What this PR does
1. check if the ManagementRequest has swbusd's service path as destination. If not, route the message
2. fix some misc issues exposed after above code change.
3. use init_logger_for_test from Logger and remove the proprietary implementation.
