### PR TITLE
Fix VNetroute primary.

### DIFF
--- a/crates/hamgrd/src/actors/ha_set.rs
+++ b/crates/hamgrd/src/actors/ha_set.rs
@@ -202,9 +202,10 @@ impl HaSetActor {
         let mut endpoint_monitor = Vec::new();
         let mut primary = Vec::new();
         let mut check_directly_connected = false;
+        let mut any_managed = false;
 
         for vdpu_ext in vdpus {
-            if vdpu_ext.vdpu.dpu.is_managed {
+            if !vdpu_ext.vdpu.dpu.remote_dpu {
                 // if it is locally managed dpu, use dpu pa_ipv4 as endpoint
                 endpoint.push(vdpu_ext.vdpu.dpu.pa_ipv4.clone());
             } else {
@@ -212,8 +213,22 @@ impl HaSetActor {
             }
 
             endpoint_monitor.push(vdpu_ext.vdpu.dpu.pa_ipv4.clone());
-            primary.push(vdpu_ext.is_primary.to_string());
-            check_directly_connected |= vdpu_ext.vdpu.dpu.is_managed;
+            if vdpu_ext.is_primary {
+                if !vdpu_ext.vdpu.dpu.remote_dpu {
+                    primary.push(vdpu_ext.vdpu.dpu.pa_ipv4.clone());
+                } else {
+                    primary.push(vdpu_ext.vdpu.dpu.npu_ipv4.clone());
+                }
+            }
+            check_directly_connected |= !vdpu_ext.vdpu.dpu.remote_dpu;
+            any_managed |= vdpu_ext.vdpu.dpu.is_managed;
+        }
+
+        if check_directly_connected && !any_managed {
+            debug!(
+                "Skipping VnetRouteTunnelTable update as directly connected DPU and no locally managed DPU are present."
+            );
+            return Ok(());
         }
 
         // update vnet route tunnel table
@@ -519,7 +534,7 @@ mod test {
                 vdpu1_state_obj.dpu.pa_ipv4.clone(),
             ]),
             monitoring: None,
-            primary: Some(vec!["true".to_string(), "false".to_string()]),
+            primary: Some(vec![vdpu0_state_obj.dpu.pa_ipv4.clone()]),
             rx_monitor_timer: global_cfg.dpu_bfd_probe_interval_in_ms,
             tx_monitor_timer: global_cfg.dpu_bfd_probe_interval_in_ms,
             check_directly_connected: Some(true),
@@ -608,7 +623,7 @@ mod test {
                 vdpu1_state_obj.dpu.pa_ipv4.clone(),
             ]),
             monitoring: None,
-            primary: Some(vec!["true".to_string(), "false".to_string()]),
+            primary: Some(vec![vdpu0_state_obj.dpu.npu_ipv4.clone()]),
             rx_monitor_timer: global_cfg.dpu_bfd_probe_interval_in_ms,
             tx_monitor_timer: global_cfg.dpu_bfd_probe_interval_in_ms,
             check_directly_connected: Some(false),


### PR DESCRIPTION
The primary field in VnetRouteTunnelTable was being set to the is_primary value instead of the primary IP address as expected. Updating to set to the correct primary IP address. 