### PR TITLE
Make deserializer more forgiven to parse dash_bfd_probe_state

### DIFF
--- a/crates/hamgrd/src/actors/dpu.rs
+++ b/crates/hamgrd/src/actors/dpu.rs
@@ -569,7 +569,7 @@ mod test {
             recv! { key: "switch0_dpu0", data: {"key": "default:default:10.0.3.0",  "operation": "Set", "field_values": bfd_fvs},
                     addr: crate::common_bridge_sp::<BfdSessionTable>(&runtime.get_swbus_edge()) },
 
-            send! { key: DashBfdProbeState::table_name(), data: { "key": "", "operation": "Set", "field_values":serde_json::to_value(to_field_values(&dpu_bfd_up_state).unwrap()).unwrap()} },
+            send! { key: DashBfdProbeState::table_name(), data: { "key": "dash_ha", "operation": "Set", "field_values":serde_json::to_value(to_field_values(&dpu_bfd_up_state).unwrap()).unwrap()} },
             recv! { key: "DPUStateUpdate|switch0_dpu0", data: dpu_actor_up_state, addr: runtime.sp("vdpu", "test-vdpu") },
 
             // Simulate DPU_STATE planes going down then up
@@ -579,7 +579,7 @@ mod test {
             recv! { key: "DPUStateUpdate|switch0_dpu0", data: dpu_actor_up_state, addr: runtime.sp("vdpu", "test-vdpu") },
 
             // Simulate BFD probe going down
-            send! { key: DashBfdProbeState::table_name(), data: { "key": "", "operation": "Set", "field_values": serde_json::to_value(to_field_values(&dpu_bfd_down_state).unwrap()).unwrap()} },
+            send! { key: DashBfdProbeState::table_name(), data: { "key": "dash_ha", "operation": "Set", "field_values": serde_json::to_value(to_field_values(&dpu_bfd_down_state).unwrap()).unwrap()} },
             recv! { key: "DPUStateUpdate|switch0_dpu0", data: dpu_actor_bfd_down_state, addr: runtime.sp("vdpu", "test-vdpu") },
 
             // simulate delete of Dpu entry

--- a/crates/hamgrd/src/db_structs.rs
+++ b/crates/hamgrd/src/db_structs.rs
@@ -144,7 +144,6 @@ impl Default for DpuState {
 }
 
 /// <https://github.com/sonic-net/SONiC/blob/master/doc/smart-switch/BFD/SmartSwitchDpuLivenessUsingBfd.md#27-dpu-bfd-session-state-updates>
-#[serde_as]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, SonicDb)]
 #[sonicdb(
     table_name = "DASH_BFD_PROBE_STATE",
@@ -153,8 +152,11 @@ impl Default for DpuState {
     is_dpu = "true"
 )]
 pub struct DashBfdProbeState {
-    #[serde(default)]
-    #[serde_as(as = "StringWithSeparator::<CommaSeparator, String>")]
+    #[serde(
+        default,
+        deserialize_with = "string_array_deserialize",
+        serialize_with = "string_array_serialize"
+    )]
     pub v4_bfd_up_sessions: Vec<String>,
     #[serde(
         default = "now_in_millis",
@@ -162,8 +164,11 @@ pub struct DashBfdProbeState {
         serialize_with = "timestamp_serialize"
     )]
     pub v4_bfd_up_sessions_timestamp: i64,
-    #[serde(default)]
-    #[serde_as(as = "StringWithSeparator::<CommaSeparator, String>")]
+    #[serde(
+        default,
+        deserialize_with = "string_array_deserialize",
+        serialize_with = "string_array_serialize"
+    )]
     pub v6_bfd_up_sessions: Vec<String>,
     #[serde(
         default = "now_in_millis",
@@ -194,6 +199,47 @@ where
     serializer.serialize_str(&formatted)
 }
 
+fn string_array_deserialize<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Handle both missing fields and present fields
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    match opt {
+        Some(s) => {
+            if s.trim().is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let sessions: Vec<String> = s
+                .split(',')
+                .map(|item| {
+                    // Trim whitespace around each item
+                    let trimmed = item.trim();
+                    // Remove enclosing single or double quotes if present
+                    let trimmed = trimmed.strip_prefix('"').unwrap_or(trimmed);
+                    let trimmed = trimmed.strip_suffix('"').unwrap_or(trimmed);
+                    let trimmed = trimmed.strip_prefix('\'').unwrap_or(trimmed);
+                    let trimmed = trimmed.strip_suffix('\'').unwrap_or(trimmed);
+                    trimmed.to_string()
+                })
+                .filter(|item| !item.is_empty()) // Filter out empty strings
+                .collect();
+
+            Ok(sessions)
+        }
+        None => Ok(Vec::new()), // Use empty vector when field is missing
+    }
+}
+
+fn string_array_serialize<S>(sessions: &[String], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let joined = sessions.join(",");
+    serializer.serialize_str(&joined)
+}
+
 fn timestamp_deserialize<'de, D>(deserializer: D) -> Result<i64, D::Error>
 where
     D: Deserializer<'de>,
@@ -202,7 +248,14 @@ where
     let opt: Option<String> = Option::deserialize(deserializer)?;
     match opt {
         Some(s) => {
-            let naive = chrono::NaiveDateTime::parse_from_str(&s, TIMESTAMP_FORMAT).map_err(de::Error::custom)?;
+            // Trim whitespace and remove enclosing single or double quotes if present
+            let s = s.trim();
+            let s = s.strip_prefix('"').unwrap_or(s);
+            let s = s.strip_suffix('"').unwrap_or(s);
+            let s = s.strip_prefix('\'').unwrap_or(s);
+            let s = s.strip_suffix('\'').unwrap_or(s);
+
+            let naive = chrono::NaiveDateTime::parse_from_str(s, TIMESTAMP_FORMAT).map_err(de::Error::custom)?;
             Ok(naive.and_utc().timestamp_millis())
         }
         None => Ok(now_in_millis()), // Use default when field is missing
@@ -700,5 +753,55 @@ mod test {
         // v6 timestamp should use default (current time)
         let now = chrono::Utc::now().timestamp_millis();
         assert!((bfd_state.v6_bfd_up_sessions_timestamp - now).abs() < 1000);
+    }
+
+    #[test]
+    fn test_bfd_sessions_quote_and_whitespace_handling() {
+        let json = r#"
+        {
+            "v4_bfd_up_sessions": " \"10.0.1.1\" , '10.0.1.2', 10.0.1.3 , \"10.0.1.4\"  ",
+            "v6_bfd_up_sessions": "'2001:db8::1', \"2001:db8::2\" ,  2001:db8::3  "
+        }"#;
+
+        let fvs: FieldValues = serde_json::from_str(json).unwrap();
+        let bfd_state: DashBfdProbeState = swss_serde::from_field_values(&fvs).unwrap();
+
+        // Test v4 sessions - should have quotes removed and whitespace trimmed
+        assert_eq!(bfd_state.v4_bfd_up_sessions.len(), 4);
+        assert_eq!(bfd_state.v4_bfd_up_sessions[0], "10.0.1.1");
+        assert_eq!(bfd_state.v4_bfd_up_sessions[1], "10.0.1.2");
+        assert_eq!(bfd_state.v4_bfd_up_sessions[2], "10.0.1.3");
+        assert_eq!(bfd_state.v4_bfd_up_sessions[3], "10.0.1.4");
+
+        // Test v6 sessions - should have quotes removed and whitespace trimmed
+        assert_eq!(bfd_state.v6_bfd_up_sessions.len(), 3);
+        assert_eq!(bfd_state.v6_bfd_up_sessions[0], "2001:db8::1");
+        assert_eq!(bfd_state.v6_bfd_up_sessions[1], "2001:db8::2");
+        assert_eq!(bfd_state.v6_bfd_up_sessions[2], "2001:db8::3");
+    }
+
+    #[test]
+    fn test_bfd_sessions_serialization_roundtrip() {
+        // Test data with quotes and whitespace
+        let json = r#"
+        {
+            "v4_bfd_up_sessions": " \"10.0.1.1\" , '10.0.1.2', 10.0.1.3 ",
+            "v6_bfd_up_sessions": "'2001:db8::1', \"2001:db8::2\""
+        }"#;
+
+        let fvs: FieldValues = serde_json::from_str(json).unwrap();
+        let bfd_state: DashBfdProbeState = swss_serde::from_field_values(&fvs).unwrap();
+
+        // Serialize back to field values
+        let serialized_fvs = swss_serde::to_field_values(&bfd_state).unwrap();
+
+        // Check that serialized format is clean comma-separated without quotes
+        assert_eq!(serialized_fvs["v4_bfd_up_sessions"], "10.0.1.1,10.0.1.2,10.0.1.3");
+        assert_eq!(serialized_fvs["v6_bfd_up_sessions"], "2001:db8::1,2001:db8::2");
+
+        // Deserialize again to ensure consistency
+        let bfd_state2: DashBfdProbeState = swss_serde::from_field_values(&serialized_fvs).unwrap();
+        assert_eq!(bfd_state.v4_bfd_up_sessions, bfd_state2.v4_bfd_up_sessions);
+        assert_eq!(bfd_state.v6_bfd_up_sessions, bfd_state2.v6_bfd_up_sessions);
     }
 }


### PR DESCRIPTION
### why
currently the deserializer for dash_bfd_probe_state has strict requirements on the format of the fields. If it doesn't follow the format, it will reject it. Specifically, the timestamp field is enclosed in double-quotes, which caused parsing error.

### what this PR does
make the deserializer more forgiven with format. If the value has double or single quotes or whitespaces, remove them first. If the value of v4_bfd_up_sessions or v6_bfd_up_sessions has quotes or space between comma, remove them.