### PR TITLE
Proper handling of entry not found in incoming vs decoding error

### DIFF
--- a/crates/hamgrd/src/actors/dpu.rs
+++ b/crates/hamgrd/src/actors/dpu.rs
@@ -12,7 +12,7 @@ use swbus_actor::{state::incoming::Incoming, state::outgoing::Outgoing, Actor, A
 use swbus_edge::SwbusEdgeRuntime;
 use swss_common::{KeyOpFieldValues, KeyOperation, SubscriberStateTable};
 use swss_common_bridge::consumer::ConsumerBridge;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, instrument};
 
 use super::spawn_consumer_bridge_for_actor_with_selector;
 
@@ -60,19 +60,30 @@ impl DpuActor {
         RemoteDpu::table_name()
     }
 
-    fn get_dpu_state(incoming: &Incoming) -> Result<DpuState> {
-        let dpu_state_kfv: KeyOpFieldValues = incoming.get(DpuState::table_name())?.deserialize_data()?;
-        Ok(swss_serde::from_field_values(&dpu_state_kfv.field_values)?)
+    fn get_dpu_state(incoming: &Incoming) -> Result<Option<DpuState>> {
+        match incoming.get(DpuState::table_name()) {
+            Some(msg) => {
+                let dpu_state_kfv: KeyOpFieldValues = msg.deserialize_data()?;
+                Ok(Some(swss_serde::from_field_values(&dpu_state_kfv.field_values)?))
+            }
+            None => Ok(None),
+        }
     }
 
-    fn get_bfd_probe_state(incoming: &Incoming) -> Result<DashBfdProbeState> {
-        let bfd_probe_kfv: KeyOpFieldValues = incoming.get(DashBfdProbeState::table_name())?.deserialize_data()?;
-        Ok(swss_serde::from_field_values(&bfd_probe_kfv.field_values)?)
+    fn get_bfd_probe_state(incoming: &Incoming) -> Result<Option<DashBfdProbeState>> {
+        match incoming.get(DashBfdProbeState::table_name()) {
+            Some(msg) => {
+                let bfd_probe_kfv: KeyOpFieldValues = msg.deserialize_data()?;
+                Ok(Some(swss_serde::from_field_values(&bfd_probe_kfv.field_values)?))
+            }
+            None => Ok(None),
+        }
     }
 
     fn get_dash_ha_global_config(incoming: &Incoming) -> Result<DashHaGlobalConfig> {
-        let ha_global_config_kfv: KeyOpFieldValues =
-            incoming.get(DashHaGlobalConfig::table_name())?.deserialize_data()?;
+        let ha_global_config_kfv: KeyOpFieldValues = incoming
+            .get_or_fail(DashHaGlobalConfig::table_name())?
+            .deserialize_data()?;
         Ok(swss_serde::from_field_values(&ha_global_config_kfv.field_values)?)
     }
 
@@ -133,7 +144,7 @@ impl DpuActor {
 
     async fn handle_dpu_message(&mut self, state: &mut State, key: &str, context: &mut Context) -> Result<()> {
         let (_internal, incoming, outgoing) = state.get_all();
-        let dpu_kfv: KeyOpFieldValues = incoming.get(key)?.deserialize_data()?;
+        let dpu_kfv: KeyOpFieldValues = incoming.get_or_fail(key)?.deserialize_data()?;
         if dpu_kfv.operation == KeyOperation::Del {
             self.do_cleanup(context, state);
             context.stop();
@@ -233,16 +244,16 @@ impl DpuActor {
         }
         // Check pmon state from DPU_STATE table
         let dpu_state = match Self::get_dpu_state(incoming) {
-            Ok(dpu_state) => Some(dpu_state),
+            Ok(dpu_state) => dpu_state,
             Err(e) => {
-                info!("Not able to get DPU state. Assume DPU is down. Error: {}", e);
+                error!("Failed to decode DPU_STATE. Error: {}", e);
                 None
             }
         };
         let bfd_probe_state = match Self::get_bfd_probe_state(incoming) {
-            Ok(bfd_probe_state) => Some(bfd_probe_state),
+            Ok(bfd_probe_state) => bfd_probe_state,
             Err(e) => {
-                debug!("Not able to get BFD probe state. Error: {}", e);
+                error!("Failed to decode DASH_BFD_PROBE_STATE. Error: {}", e);
                 None
             }
         };
@@ -310,7 +321,9 @@ impl DpuActor {
 
     // handle DPU state registration request. In response to the request, this actor will send its current state.
     fn handle_dpu_state_registration(&mut self, key: &str, incoming: &Incoming, outgoing: &mut Outgoing) -> Result<()> {
-        let entry = incoming.get_entry(key)?;
+        let entry = incoming
+            .get_entry(key)
+            .ok_or_else(|| anyhow!("Entry not found for key: {}", key))?;
         let ActorRegistration { active, .. } = entry.msg.deserialize_data()?;
         if active {
             self.update_dpu_state(incoming, outgoing, Some(entry.source.clone()))?;
@@ -406,7 +419,7 @@ impl DpuActor {
         context: &mut Context,
     ) -> Result<()> {
         let (_internal, incoming, outgoing) = state.get_all();
-        let dpu_kfv: KeyOpFieldValues = incoming.get(key)?.deserialize_data()?;
+        let dpu_kfv: KeyOpFieldValues = incoming.get_or_fail(key)?.deserialize_data()?;
         if dpu_kfv.operation == KeyOperation::Del {
             context.stop();
             return Ok(());
@@ -421,7 +434,7 @@ impl DpuActor {
 
     fn handle_remote_dpu_message_to_local_dpu(&mut self, state: &mut State, key: &str) -> Result<()> {
         let (_internal, incoming, outgoing) = state.get_all();
-        let dpu_kfv: KeyOpFieldValues = incoming.get(key)?.deserialize_data()?;
+        let dpu_kfv: KeyOpFieldValues = incoming.get_or_fail(key)?.deserialize_data()?;
 
         let remote_dpu: RemoteDpu = swss_serde::from_field_values(&dpu_kfv.field_values)?;
 

--- a/crates/hamgrd/src/actors/ha_set.rs
+++ b/crates/hamgrd/src/actors/ha_set.rs
@@ -48,7 +48,7 @@ struct VDpuStateExt {
 
 impl HaSetActor {
     fn get_dash_global_config(incoming: &Incoming) -> Option<DashHaGlobalConfig> {
-        let Ok(msg) = incoming.get(DashHaGlobalConfig::table_name()) else {
+        let Some(msg) = incoming.get(DashHaGlobalConfig::table_name()) else {
             debug!("DASH_HA_GLOBAL_CONFIG table is not available");
             return None;
         };
@@ -283,10 +283,14 @@ impl HaSetActor {
     // get vdpu data received via vdpu udpate
     fn get_vdpu(&self, incoming: &Incoming, vdpu_id: &str) -> Option<VDpuActorState> {
         let key = VDpuActorState::msg_key(vdpu_id);
-        let Ok(msg) = incoming.get(&key) else {
-            return None;
-        };
-        msg.deserialize_data().ok()
+        let msg = incoming.get(&key)?;
+        match msg.deserialize_data() {
+            Ok(vdpu) => Some(vdpu),
+            Err(e) => {
+                error!("Failed to deserialize VDpuActorState from the message: {}", e);
+                None
+            }
+        }
     }
 
     /// Get vdpu data received via vdpu update and return them in a list with primary DPUs first.
@@ -351,7 +355,7 @@ impl HaSetActor {
         context: &mut Context,
     ) -> Result<()> {
         let (_internal, incoming, outgoing) = state.get_all();
-        let dpu_kfv: KeyOpFieldValues = incoming.get(key)?.deserialize_data()?;
+        let dpu_kfv: KeyOpFieldValues = incoming.get_or_fail(key)?.deserialize_data()?;
         if dpu_kfv.operation == KeyOperation::Del {
             // cleanup resources before stopping
             if let Err(e) = self.do_cleanup(state) {
@@ -413,7 +417,9 @@ impl HaSetActor {
     async fn handle_haset_state_registration(&mut self, state: &mut State, key: &str) -> Result<()> {
         let (_, incoming, outgoing) = state.get_all();
 
-        let entry = incoming.get_entry(key)?;
+        let entry = incoming
+            .get_entry(key)
+            .ok_or_else(|| anyhow!("Entry not found for key: {}", key))?;
         let ActorRegistration { active, .. } = entry.msg.deserialize_data()?;
         if active {
             let Some(vdpus) = self.get_vdpus_if_ready(incoming) else {

--- a/crates/swbus-actor/src/state.rs
+++ b/crates/swbus-actor/src/state.rs
@@ -40,7 +40,7 @@ impl State {
     /// # fn foo() -> anyhow::Result<()> {
     /// # let state: swbus_actor::State = todo!();
     /// let (internal, incoming, outgoing) = state.get_all();
-    /// let x = incoming.get("x")?;
+    /// let x = incoming.get_or_fail("x")?;
     /// let tbl = internal.get_mut("tbl");
     /// tbl["x"] = x.deserialize_data::<String>()?.into();
     /// // Ok

--- a/crates/swbus-actor/tests/echo.rs
+++ b/crates/swbus-actor/tests/echo.rs
@@ -48,7 +48,10 @@ impl Actor for EchoClient {
 
         // Assert that the incoming table has messages 0..=count still cached
         for i in 0..=count {
-            let n = state.incoming().get(&format!("{i}"))?.deserialize_data::<u32>()?;
+            let n = state
+                .incoming()
+                .get_or_fail(&format!("{i}"))?
+                .deserialize_data::<u32>()?;
             assert_eq!(n, i);
         }
 

--- a/crates/swbus-actor/tests/kvstore.rs
+++ b/crates/swbus-actor/tests/kvstore.rs
@@ -354,7 +354,7 @@ impl Actor for KVClient {
         }
 
         assert_eq!(key, "kv-get");
-        let KVGetResult { key, val } = state.incoming().get(key)?.deserialize_data::<KVGetResult>()?;
+        let KVGetResult { key, val } = state.incoming().get_or_fail(key)?.deserialize_data::<KVGetResult>()?;
 
         match &*key {
             "count" => {


### PR DESCRIPTION
### why
currently Incoming::get returns error if the entry is not found and caller typically propagates the error further. Sometimes it is normal that an entry doesn't exist. It needs to be treated differently from message decode error.

### what this PR does
Incoming::get returns Option. Caller needs to handle the None return accordingly, which means the entry is not found.