### PR TITLE
Unregister handlers after actor terminates

### DIFF
--- a/crates/hamgrd/src/actors.rs
+++ b/crates/hamgrd/src/actors.rs
@@ -289,7 +289,7 @@ where
 
     let sp = crate::common_bridge_sp::<T>(&edge_runtime);
     info!(
-        "spawned ZMQ producer bridge for {} at {}",
+        "spawned producer bridge for {} at {}",
         T::table_name(),
         sp.to_longest_path()
     );

--- a/crates/hamgrd/src/actors/dpu.rs
+++ b/crates/hamgrd/src/actors/dpu.rs
@@ -12,7 +12,7 @@ use swbus_actor::{state::incoming::Incoming, state::outgoing::Outgoing, Actor, A
 use swbus_edge::SwbusEdgeRuntime;
 use swss_common::{KeyOpFieldValues, KeyOperation, SubscriberStateTable};
 use swss_common_bridge::consumer::ConsumerBridge;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, instrument};
 
 use super::spawn_consumer_bridge_for_actor_with_selector;
 
@@ -60,19 +60,30 @@ impl DpuActor {
         RemoteDpu::table_name()
     }
 
-    fn get_dpu_state(incoming: &Incoming) -> Result<DpuState> {
-        let dpu_state_kfv: KeyOpFieldValues = incoming.get(DpuState::table_name())?.deserialize_data()?;
-        Ok(swss_serde::from_field_values(&dpu_state_kfv.field_values)?)
+    fn get_dpu_state(incoming: &Incoming) -> Result<Option<DpuState>> {
+        match incoming.get(DpuState::table_name()) {
+            Some(msg) => {
+                let dpu_state_kfv: KeyOpFieldValues = msg.deserialize_data()?;
+                Ok(Some(swss_serde::from_field_values(&dpu_state_kfv.field_values)?))
+            }
+            None => Ok(None),
+        }
     }
 
-    fn get_bfd_probe_state(incoming: &Incoming) -> Result<DashBfdProbeState> {
-        let bfd_probe_kfv: KeyOpFieldValues = incoming.get(DashBfdProbeState::table_name())?.deserialize_data()?;
-        Ok(swss_serde::from_field_values(&bfd_probe_kfv.field_values)?)
+    fn get_bfd_probe_state(incoming: &Incoming) -> Result<Option<DashBfdProbeState>> {
+        match incoming.get(DashBfdProbeState::table_name()) {
+            Some(msg) => {
+                let bfd_probe_kfv: KeyOpFieldValues = msg.deserialize_data()?;
+                Ok(Some(swss_serde::from_field_values(&bfd_probe_kfv.field_values)?))
+            }
+            None => Ok(None),
+        }
     }
 
     fn get_dash_ha_global_config(incoming: &Incoming) -> Result<DashHaGlobalConfig> {
-        let ha_global_config_kfv: KeyOpFieldValues =
-            incoming.get(DashHaGlobalConfig::table_name())?.deserialize_data()?;
+        let ha_global_config_kfv: KeyOpFieldValues = incoming
+            .get_or_fail(DashHaGlobalConfig::table_name())?
+            .deserialize_data()?;
         Ok(swss_serde::from_field_values(&ha_global_config_kfv.field_values)?)
     }
 
@@ -133,7 +144,7 @@ impl DpuActor {
 
     async fn handle_dpu_message(&mut self, state: &mut State, key: &str, context: &mut Context) -> Result<()> {
         let (_internal, incoming, outgoing) = state.get_all();
-        let dpu_kfv: KeyOpFieldValues = incoming.get(key)?.deserialize_data()?;
+        let dpu_kfv: KeyOpFieldValues = incoming.get_or_fail(key)?.deserialize_data()?;
         if dpu_kfv.operation == KeyOperation::Del {
             self.do_cleanup(context, state);
             context.stop();
@@ -233,16 +244,16 @@ impl DpuActor {
         }
         // Check pmon state from DPU_STATE table
         let dpu_state = match Self::get_dpu_state(incoming) {
-            Ok(dpu_state) => Some(dpu_state),
+            Ok(dpu_state) => dpu_state,
             Err(e) => {
-                info!("Not able to get DPU state. Assume DPU is down. Error: {}", e);
+                error!("Failed to decode DPU_STATE. Error: {}", e);
                 None
             }
         };
         let bfd_probe_state = match Self::get_bfd_probe_state(incoming) {
-            Ok(bfd_probe_state) => Some(bfd_probe_state),
+            Ok(bfd_probe_state) => bfd_probe_state,
             Err(e) => {
-                debug!("Not able to get BFD probe state. Error: {}", e);
+                error!("Failed to decode DASH_BFD_PROBE_STATE. Error: {}", e);
                 None
             }
         };
@@ -310,7 +321,9 @@ impl DpuActor {
 
     // handle DPU state registration request. In response to the request, this actor will send its current state.
     fn handle_dpu_state_registration(&mut self, key: &str, incoming: &Incoming, outgoing: &mut Outgoing) -> Result<()> {
-        let entry = incoming.get_entry(key)?;
+        let entry = incoming
+            .get_entry(key)
+            .ok_or_else(|| anyhow!("Entry not found for key: {}", key))?;
         let ActorRegistration { active, .. } = entry.msg.deserialize_data()?;
         if active {
             self.update_dpu_state(incoming, outgoing, Some(entry.source.clone()))?;
@@ -406,7 +419,7 @@ impl DpuActor {
         context: &mut Context,
     ) -> Result<()> {
         let (_internal, incoming, outgoing) = state.get_all();
-        let dpu_kfv: KeyOpFieldValues = incoming.get(key)?.deserialize_data()?;
+        let dpu_kfv: KeyOpFieldValues = incoming.get_or_fail(key)?.deserialize_data()?;
         if dpu_kfv.operation == KeyOperation::Del {
             context.stop();
             return Ok(());
@@ -421,7 +434,7 @@ impl DpuActor {
 
     fn handle_remote_dpu_message_to_local_dpu(&mut self, state: &mut State, key: &str) -> Result<()> {
         let (_internal, incoming, outgoing) = state.get_all();
-        let dpu_kfv: KeyOpFieldValues = incoming.get(key)?.deserialize_data()?;
+        let dpu_kfv: KeyOpFieldValues = incoming.get_or_fail(key)?.deserialize_data()?;
 
         let remote_dpu: RemoteDpu = swss_serde::from_field_values(&dpu_kfv.field_values)?;
 

--- a/crates/hamgrd/src/actors/ha_set.rs
+++ b/crates/hamgrd/src/actors/ha_set.rs
@@ -48,7 +48,7 @@ struct VDpuStateExt {
 
 impl HaSetActor {
     fn get_dash_global_config(incoming: &Incoming) -> Option<DashHaGlobalConfig> {
-        let Ok(msg) = incoming.get(DashHaGlobalConfig::table_name()) else {
+        let Some(msg) = incoming.get(DashHaGlobalConfig::table_name()) else {
             debug!("DASH_HA_GLOBAL_CONFIG table is not available");
             return None;
         };
@@ -283,10 +283,14 @@ impl HaSetActor {
     // get vdpu data received via vdpu udpate
     fn get_vdpu(&self, incoming: &Incoming, vdpu_id: &str) -> Option<VDpuActorState> {
         let key = VDpuActorState::msg_key(vdpu_id);
-        let Ok(msg) = incoming.get(&key) else {
-            return None;
-        };
-        msg.deserialize_data().ok()
+        let msg = incoming.get(&key)?;
+        match msg.deserialize_data() {
+            Ok(vdpu) => Some(vdpu),
+            Err(e) => {
+                error!("Failed to deserialize VDpuActorState from the message: {}", e);
+                None
+            }
+        }
     }
 
     /// Get vdpu data received via vdpu update and return them in a list with primary DPUs first.
@@ -351,7 +355,7 @@ impl HaSetActor {
         context: &mut Context,
     ) -> Result<()> {
         let (_internal, incoming, outgoing) = state.get_all();
-        let dpu_kfv: KeyOpFieldValues = incoming.get(key)?.deserialize_data()?;
+        let dpu_kfv: KeyOpFieldValues = incoming.get_or_fail(key)?.deserialize_data()?;
         if dpu_kfv.operation == KeyOperation::Del {
             // cleanup resources before stopping
             if let Err(e) = self.do_cleanup(state) {
@@ -413,7 +417,9 @@ impl HaSetActor {
     async fn handle_haset_state_registration(&mut self, state: &mut State, key: &str) -> Result<()> {
         let (_, incoming, outgoing) = state.get_all();
 
-        let entry = incoming.get_entry(key)?;
+        let entry = incoming
+            .get_entry(key)
+            .ok_or_else(|| anyhow!("Entry not found for key: {}", key))?;
         let ActorRegistration { active, .. } = entry.msg.deserialize_data()?;
         if active {
             let Some(vdpus) = self.get_vdpus_if_ready(incoming) else {

--- a/crates/swbus-actor/src/state.rs
+++ b/crates/swbus-actor/src/state.rs
@@ -40,7 +40,7 @@ impl State {
     /// # fn foo() -> anyhow::Result<()> {
     /// # let state: swbus_actor::State = todo!();
     /// let (internal, incoming, outgoing) = state.get_all();
-    /// let x = incoming.get("x")?;
+    /// let x = incoming.get_or_fail("x")?;
     /// let tbl = internal.get_mut("tbl");
     /// tbl["x"] = x.deserialize_data::<String>()?.into();
     /// // Ok

--- a/crates/swbus-actor/tests/echo.rs
+++ b/crates/swbus-actor/tests/echo.rs
@@ -14,12 +14,31 @@ fn sp(name: &str) -> ServicePath {
 async fn echo() {
     let mut swbus_edge = SwbusEdgeRuntime::new("none".to_string(), sp("none"), ConnectionType::InNode);
     swbus_edge.start().await.unwrap();
-    let actor_runtime = ActorRuntime::new(swbus_edge.into());
+    let actor_runtime: ActorRuntime = ActorRuntime::new(swbus_edge.into());
     swbus_actor::set_global_runtime(actor_runtime);
 
     let (notify_done, is_done) = channel();
 
     swbus_actor::spawn(EchoServer, "test", "echo");
+    swbus_actor::spawn(EchoClient(notify_done), "test", "client");
+
+    timeout(Duration::from_secs(3), is_done)
+        .await
+        .expect("timeout")
+        .unwrap();
+
+    {
+        // Access the actor runtime to get the service path and check if handler exists
+        let runtime_guard = swbus_actor::get_global_runtime();
+        let runtime = runtime_guard.as_ref().unwrap();
+        let sp = runtime.sp("test", "client");
+        let has_handler = runtime.get_swbus_edge().has_handler(&sp);
+        assert!(!has_handler);
+    }
+
+    let (notify_done, is_done) = channel();
+
+    // spawn the same actor to make sure the previous actor cleans up properly
     swbus_actor::spawn(EchoClient(notify_done), "test", "client");
 
     timeout(Duration::from_secs(3), is_done)
@@ -43,7 +62,7 @@ impl Actor for EchoClient {
         Ok(())
     }
 
-    async fn handle_message(&mut self, state: &mut State, key: &str, _context: &mut Context) -> Result<()> {
+    async fn handle_message(&mut self, state: &mut State, key: &str, context: &mut Context) -> Result<()> {
         let count = key.parse::<u32>().unwrap();
 
         // Assert that the incoming table has messages 0..=count still cached
@@ -54,6 +73,8 @@ impl Actor for EchoClient {
 
         if count == 1000 {
             self.notify_done();
+            // terminate this actor
+            context.stop();
         } else {
             state
                 .outgoing()

--- a/crates/swbus-actor/tests/echo.rs
+++ b/crates/swbus-actor/tests/echo.rs
@@ -67,7 +67,10 @@ impl Actor for EchoClient {
 
         // Assert that the incoming table has messages 0..=count still cached
         for i in 0..=count {
-            let n = state.incoming().get(&format!("{i}"))?.deserialize_data::<u32>()?;
+            let n = state
+                .incoming()
+                .get_or_fail(&format!("{i}"))?
+                .deserialize_data::<u32>()?;
             assert_eq!(n, i);
         }
 

--- a/crates/swbus-actor/tests/kvstore.rs
+++ b/crates/swbus-actor/tests/kvstore.rs
@@ -354,7 +354,7 @@ impl Actor for KVClient {
         }
 
         assert_eq!(key, "kv-get");
-        let KVGetResult { key, val } = state.incoming().get(key)?.deserialize_data::<KVGetResult>()?;
+        let KVGetResult { key, val } = state.incoming().get_or_fail(key)?.deserialize_data::<KVGetResult>()?;
 
         match &*key {
             "count" => {

--- a/crates/swbus-edge/src/edge_runtime.rs
+++ b/crates/swbus-edge/src/edge_runtime.rs
@@ -74,6 +74,23 @@ impl SwbusEdgeRuntime {
         self.message_router.add_private_route(svc_path, proxy);
     }
 
+    /// Remove handler by ServicePath.
+    pub fn remove_handler(&self, svc_path: &ServicePath) -> bool {
+        match self.message_router.remove_route(svc_path) {
+            Some(_) => {
+                info!("Removed handler for service path: {}", svc_path.to_longest_path());
+                true
+            }
+            None => {
+                info!(
+                    "No handler found to remove for service path: {}",
+                    svc_path.to_longest_path()
+                );
+                false
+            }
+        }
+    }
+
     pub async fn send(&self, message: SwbusMessage) -> Result<()> {
         // Send message to the message router
         match self.sender_to_message_router.send(message).await {

--- a/crates/swbus-edge/src/edge_runtime.rs
+++ b/crates/swbus-edge/src/edge_runtime.rs
@@ -91,6 +91,11 @@ impl SwbusEdgeRuntime {
         }
     }
 
+    /// Check if a handler exists for the given ServicePath.
+    pub fn has_handler(&self, svc_path: &ServicePath) -> bool {
+        self.message_router.has_route(svc_path)
+    }
+
     pub async fn send(&self, message: SwbusMessage) -> Result<()> {
         // Send message to the message router
         match self.sender_to_message_router.send(message).await {

--- a/crates/swbus-edge/src/message_router.rs
+++ b/crates/swbus-edge/src/message_router.rs
@@ -81,6 +81,10 @@ impl SwbusMessageRouter {
         self.routes.remove(svc_path).map(|(handler, _)| handler)
     }
 
+    pub fn has_route(&self, svc_path: &ServicePath) -> bool {
+        self.routes.contains(svc_path)
+    }
+
     async fn route_message(
         swbus_client: &mut SwbusCoreClient,
         routes: &RouteMap,

--- a/crates/swbus-edge/src/message_router.rs
+++ b/crates/swbus-edge/src/message_router.rs
@@ -77,6 +77,10 @@ impl SwbusMessageRouter {
         self.routes.insert(svc_path, handler, Privacy::Private);
     }
 
+    pub fn remove_route(&self, svc_path: &ServicePath) -> Option<SwbusMessageHandlerProxy> {
+        self.routes.remove(svc_path).map(|(handler, _)| handler)
+    }
+
     async fn route_message(
         swbus_client: &mut SwbusCoreClient,
         routes: &RouteMap,

--- a/crates/swbus-edge/src/message_router/route_map.rs
+++ b/crates/swbus-edge/src/message_router/route_map.rs
@@ -26,4 +26,8 @@ impl RouteMap {
     pub(super) fn remove(&self, svc_path: &ServicePath) -> Option<(SwbusMessageHandlerProxy, Privacy)> {
         self.0.remove(svc_path).map(|(_, value)| value)
     }
+
+    pub(super) fn contains(&self, svc_path: &ServicePath) -> bool {
+        self.0.contains_key(svc_path)
+    }
 }

--- a/crates/swbus-edge/src/message_router/route_map.rs
+++ b/crates/swbus-edge/src/message_router/route_map.rs
@@ -22,4 +22,8 @@ impl RouteMap {
             }
         })
     }
+
+    pub(super) fn remove(&self, svc_path: &ServicePath) -> Option<(SwbusMessageHandlerProxy, Privacy)> {
+        self.0.remove(svc_path).map(|(_, value)| value)
+    }
 }

--- a/crates/swbus-edge/src/simple_client.rs
+++ b/crates/swbus-edge/src/simple_client.rs
@@ -238,3 +238,9 @@ pub struct OutgoingMessage {
     pub destination: ServicePath,
     pub body: MessageBody,
 }
+
+impl Drop for SimpleSwbusEdgeClient {
+    fn drop(&mut self) {
+        self.rt.remove_handler(&self.source);
+    }
+}


### PR DESCRIPTION
### why
when actor terminates itself, the handler in SwbusEdgeRuntime is not removed. When a new actor is spawned with the same service path, it will be ignored because the ActorCreator replies on "NoRoute" to discover new actor.

### what this PR does
when ActorDriver exits from run loop, the SimpleSwbusEdgeClient it owns will be destructed. From the destructor, handler will be removed.