### PR TITLE
[build] Disable debian helper auto install for cargo project.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,10 @@
 override_dh_auto_build:
 	cargo build --release --all
 
+override_dh_auto_install:
+	# do nothing
+	:
+
 override_dh_auto_clean:
 	cargo clean --release
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**
Disable dh_auto_install
**Why I did it**
Rust and Go project don't need auto install. Just copying binary file to /bin/bash.
Disable dh_auto_install to avoid runing 'cargo install'. 'cargo install' will download latest version for each dependency.
It may break when dependency has a new release.
**How I verified it**

**Details if related**