### PR TITLE
Write DASH_DPU_RESET_INFO_TABLE when dpu midplane or control plane down

### DIFF
--- a/crates/hamgrd/src/db_structs.rs
+++ b/crates/hamgrd/src/db_structs.rs
@@ -381,8 +381,8 @@ pub struct DpuDashHaScopeState {
 /// Key format: DPU{dpu_id} (e.g., DPU0, DPU1, ..., DPU7)
 #[skip_serializing_none]
 #[derive(Debug, Deserialize, Serialize, PartialEq, Default, Clone, SonicDb)]
-#[sonicdb(table_name = "DASH_DPU_RESET_INFO", key_separator = "|", db_name = "STATE_DB")]
-pub struct DashDpuResetInfo {
+#[sonicdb(table_name = "DPU_RESET_INFO", key_separator = "|", db_name = "STATE_DB")]
+pub struct DpuResetInfo {
     /// Reset status: true means DPU has reset (midplane or control plane went down)
     pub reset_status: bool,
     /// Timestamp in milliseconds when reset was detected


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**
When dpu midplane or control plane go down, write DASH_DPU_RESET_INFO_TABLE
**Why I did it**
This is to handle DPU reboot or DPU critical process restart. We use the table to notify SDN controller to take action. For details, see https://github.com/sonic-net/SONiC/pull/2175
**How I verified it**
verified in hardware.
when dpu is rebooted, or some critical process restarted, below entry was created or updated
root@MtFuji-dut02:/home/cisco# sonic-db-cli STATE_DB hgetall DASH_DPU_RESET_INFO\|DPU0
{'timestamp': '1769715782213', 'dpu_id': 'dpu1_0', 'vdpu_id': 'vdpu1_0', 'reset_status': 'true'}

**Details if related**