### PR TITLE
Change convert_pb_to_json to parse proto encoded value from binary input

### DIFF
--- a/crates/sonic-common/src/lib.rs
+++ b/crates/sonic-common/src/lib.rs
@@ -10,9 +10,10 @@ pub trait SonicDbTable {
     fn is_proto() -> bool {
         false
     }
-    fn convert_pb_to_json(_kfv: &mut KeyOpFieldValues) {
+    fn convert_pb_to_json(_kfv: &mut KeyOpFieldValues) -> Result<(), Box<dyn std::error::Error>> {
         // Default implementation does nothing.
         // This can be overridden by the macro to convert protobuf to JSON.
+        Ok(())
     }
     fn is_dpu() -> bool;
 }

--- a/crates/sonicdb-derive/src/lib.rs
+++ b/crates/sonicdb-derive/src/lib.rs
@@ -82,6 +82,11 @@ pub fn serde_sonicdb_derive(input: TokenStream) -> TokenStream {
                 true
             }
             fn convert_pb_to_json(kfv: &mut swss_common::KeyOpFieldValues) -> Result<(), Box<dyn std::error::Error>> {
+                // Skip pb processing for delete operations
+                if kfv.operation == swss_common::KeyOperation::Del {
+                    return Ok(());
+                }
+
                 let value_bytes = match kfv.field_values.get("pb") {
                     Some(v) => v.as_bytes(),
                     None => return Err("Missing 'pb' field".into()),

--- a/crates/sonicdb-derive/src/lib.rs
+++ b/crates/sonicdb-derive/src/lib.rs
@@ -81,30 +81,23 @@ pub fn serde_sonicdb_derive(input: TokenStream) -> TokenStream {
             fn is_proto() -> bool {
                 true
             }
-            fn convert_pb_to_json(kfv: &mut swss_common::KeyOpFieldValues) {
-                let value_hex = match kfv.field_values.get("pb") {
-                    Some(v) => v.to_str().ok(),
-                    None => None,
-                };
-                let value_hex = match value_hex {
-                    Some(s) if !s.is_empty() => s,
-                    _ => return,
-                };
-                let value_bytes = match hex::decode(value_hex) {
-                    Ok(bytes) => bytes,
-                    Err(_) => return,
-                };
-                let config = match #struct_name::decode(&*value_bytes) {
-                    Ok(cfg) => cfg,
-                    Err(_) => return,
+            fn convert_pb_to_json(kfv: &mut swss_common::KeyOpFieldValues) -> Result<(), Box<dyn std::error::Error>> {
+                let value_bytes = match kfv.field_values.get("pb") {
+                    Some(v) => v.as_bytes(),
+                    None => return Err("Missing 'pb' field".into()),
                 };
 
-                let json = match serde_json::to_string(&config) {
-                    Ok(j) => j,
-                    Err(_) => return,
-                };
+                if value_bytes.is_empty() {
+                    return Err("Empty 'pb' field".into());
+                }
+
+                let config = #struct_name::decode(value_bytes)?;
+
+                let json = serde_json::to_string(&config)?;
+
                 kfv.field_values.clear();
                 kfv.field_values.insert("json".to_string(), json.into());
+                Ok(())
             }
         }
     } else {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**
1. Change convert_pb_to_json to parse protobuf encoded data directly from binary input.
2. log an error if it failed to convert protobuf encoded value to json
**Why I did it**
sonic stores protobuf encoded data in binary format in sonic-db, not hex string.
**How I verified it**
Use gnmi to write DASH_HA_SET_CONFIG_TABLE and verified hamgrd is able to parse it.
**Details if related**