### PR TITLE
Add a dedicated always-on logging file for hamgrd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-error = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "serde"] }
 syslog-tracing = "0.3"
+file-rotate = "0.7"
 thiserror = "1"
 anyhow = "1"
 human-panic = "2"

--- a/crates/hamgrd/src/main.rs
+++ b/crates/hamgrd/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Ok};
 use clap::Parser;
-use sonic_common::log;
+use sonic_common::log::{self, FileLogConfig};
 use sonic_common::SonicDbTable;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::{

--- a/crates/hamgrd/src/main.rs
+++ b/crates/hamgrd/src/main.rs
@@ -50,7 +50,7 @@ async fn main() {
         "hamgrd",
         true,
         Some(FileLogConfig {
-            log_file_path: "/var/log/dash-ha/swbusd.rec".to_string(),
+            log_file_path: format!("/var/log/dash-ha/hamgrd-dpu{}.rec", args.slot_id as u8),
             max_file_size_bytes: 1 << 26,
             max_file_count: usize::MAX,
             targets: vec!["swbus_actor::driver".to_string()],

--- a/crates/hamgrd/src/main.rs
+++ b/crates/hamgrd/src/main.rs
@@ -53,7 +53,7 @@ async fn main() {
             log_file_path: format!("/var/log/dash-ha/hamgrd-dpu{}.rec", args.slot_id as u8),
             max_file_size_bytes: 1 << 26,
             max_file_count: usize::MAX,
-            targets: vec!["swbus_actor::driver".to_string()],
+            targets: vec!["swbus_actor::driver".to_string(), "hamgrd-recorder".to_string()],
         }),
     ) {
         eprintln!("Failed to initialize logging: {e}");

--- a/crates/hamgrd/src/main.rs
+++ b/crates/hamgrd/src/main.rs
@@ -46,7 +46,7 @@ struct Args {
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
-    if let Err(e) = log::init("hamgrd", true) {
+    if let Err(e) = log::init("hamgrd", true, None) {
         eprintln!("Failed to initialize logging: {e}");
     }
 

--- a/crates/hamgrd/src/main.rs
+++ b/crates/hamgrd/src/main.rs
@@ -46,7 +46,16 @@ struct Args {
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
-    if let Err(e) = log::init("hamgrd", true, None) {
+    if let Err(e) = log::init(
+        "hamgrd",
+        true,
+        Some(FileLogConfig {
+            log_file_path: "/var/log/dash-ha/swbusd.rec".to_string(),
+            max_file_size_bytes: 1 << 26,
+            max_file_count: usize::MAX,
+            targets: vec!["swbus_actor::driver".to_string()],
+        }),
+    ) {
         eprintln!("Failed to initialize logging: {e}");
     }
 

--- a/crates/sonic-common/Cargo.toml
+++ b/crates/sonic-common/Cargo.toml
@@ -18,6 +18,7 @@ tracing.workspace = true
 tracing-error.workspace = true
 tracing-subscriber.workspace = true
 syslog-tracing.workspace = true
+file-rotate.workspace = true
 better-panic.workspace = true
 human-panic.workspace = true
 signal-hook.workspace = true

--- a/crates/sonic-common/src/log.rs
+++ b/crates/sonic-common/src/log.rs
@@ -75,7 +75,8 @@ impl LoggerConfigChangeHandler for LoggerConfigHandler {
 ///   - log_level: emerg, alert, crit, error, warn, notice, info, debug
 ///   - output: stdout, stderr, syslog. Rust doesn't support dynamically changing log output. We will only support default output (syslog in linux, file in windows)
 /// * If file_log is provided, an additional file logging layer is created that writes records matching the specified
-///   module targets to a daily-rotating log file. This is independent of the main syslog/file output.
+///   module targets to a size-based, rotating log file (see FileLogConfig for size and count limits). This is independent
+///   of the main syslog/file output.
 pub fn init(program_name: &'static str, link_swsscommon_logger: bool, file_log: Option<FileLogConfig>) -> Result<()> {
     let log_level_env_var = format!("{}_LOG_LEVEL", program_name.to_uppercase());
 

--- a/crates/sonic-common/src/log.rs
+++ b/crates/sonic-common/src/log.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::{Context, Result};
+use std::path::Path;
 #[cfg(target_os = "windows")]
 use std::path::PathBuf;
 
@@ -13,6 +14,19 @@ use tracing_subscriber::{
     self, filter, fmt, fmt::format::FmtSpan, prelude::__tracing_subscriber_SubscriberExt, reload,
     util::SubscriberInitExt, Layer, Registry,
 };
+
+/// Configuration for logging specific module targets to an independent file.
+pub struct FileLogConfig {
+    /// Full path to the log file. Rotated files will be named `{path}.1`, `{path}.2`, etc.
+    pub log_file_path: String,
+    /// Maximum size in bytes before the log file is rotated.
+    pub max_file_size_bytes: usize,
+    /// Number of rotated files to keep (e.g. 5 means file, file.1, ..., file.5).
+    pub max_file_count: usize,
+    /// Module target prefixes to route to the file (e.g. `["hamgrd::actors", "swbus_core"]`).
+    /// Log records whose target starts with any of these prefixes are written to the file.
+    pub targets: Vec<String>,
+}
 
 lazy_static! {
     static ref LOG_FOR_TEST_INIT: Mutex<bool> = Mutex::new(false);
@@ -60,7 +74,9 @@ impl LoggerConfigChangeHandler for LoggerConfigHandler {
 ///   by modifying config_db. The settings include
 ///   - log_level: emerg, alert, crit, error, warn, notice, info, debug
 ///   - output: stdout, stderr, syslog. Rust doesn't support dynamically changing log output. We will only support default output (syslog in linux, file in windows)
-pub fn init(program_name: &'static str, link_swsscommon_logger: bool) -> Result<()> {
+/// * If file_log is provided, an additional file logging layer is created that writes records matching the specified
+///   module targets to a daily-rotating log file. This is independent of the main syslog/file output.
+pub fn init(program_name: &'static str, link_swsscommon_logger: bool, file_log: Option<FileLogConfig>) -> Result<()> {
     let log_level_env_var = format!("{}_LOG_LEVEL", program_name.to_uppercase());
 
     let mut log_env_set = true;
@@ -76,6 +92,7 @@ pub fn init(program_name: &'static str, link_swsscommon_logger: bool) -> Result<
     );
 
     let file_subscriber = new_file_subscriber(program_name).wrap_err("Unable to create file subscriber.")?;
+    let file_log_layer = new_independent_file_layer(file_log)?;
 
     #[cfg(not(target_os = "windows"))]
     if link_swsscommon_logger && !log_env_set {
@@ -92,10 +109,14 @@ pub fn init(program_name: &'static str, link_swsscommon_logger: bool) -> Result<
                 .with_target(false)
                 .with_ansi(false);
 
-            tracing_subscriber::registry()
-                .with(level_layer.and_then(file_subscriber))
-                .with(ErrorLayer::default())
-                .init();
+            let mut layers: Vec<Box<dyn Layer<Registry> + Send + Sync>> = Vec::new();
+            layers.push(Box::new(level_layer.and_then(file_subscriber)));
+            if let Some(fl) = file_log_layer {
+                layers.push(fl);
+            }
+            layers.push(Box::new(ErrorLayer::default()));
+
+            tracing_subscriber::registry().with(layers).init();
             return Ok(());
         } else {
             eprintln!("Unable to link to swsscommon logger: {}", result.unwrap_err());
@@ -110,12 +131,61 @@ pub fn init(program_name: &'static str, link_swsscommon_logger: bool) -> Result<
         .with_ansi(false)
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
 
-    tracing_subscriber::registry()
-        .with(filter.and_then(file_subscriber))
-        .with(ErrorLayer::default())
-        .init();
+    let mut layers: Vec<Box<dyn Layer<Registry> + Send + Sync>> = Vec::new();
+    layers.push(Box::new(filter.and_then(file_subscriber)));
+    if let Some(fl) = file_log_layer {
+        layers.push(fl);
+    }
+    layers.push(Box::new(ErrorLayer::default()));
+
+    tracing_subscriber::registry().with(layers).init();
 
     Ok(())
+}
+
+/// Creates an optional independent file logging layer.
+/// When `file_log` is `Some`, returns a boxed layer that writes log records whose target starts
+/// with any of the configured prefixes to a size-rotated file (like syslog: file, file.1, file.2, etc.).
+fn new_independent_file_layer(
+    file_log: Option<FileLogConfig>,
+) -> Result<Option<Box<dyn Layer<Registry> + Send + Sync>>> {
+    use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
+
+    let config = match file_log {
+        Some(c) => c,
+        None => return Ok(None),
+    };
+
+    let log_path = Path::new(&config.log_file_path);
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent).wrap_err(format!("Unable to create log directory: {:?}", parent))?;
+    }
+
+    let file_rotate = FileRotate::new(
+        log_path,
+        AppendCount::new(config.max_file_count),
+        ContentLimit::Bytes(config.max_file_size_bytes),
+        Compression::OnRotate(2),
+        #[cfg(unix)]
+        None,
+    );
+    let file_rotate = Mutex::new(file_rotate);
+
+    let targets = config.targets;
+    let mut target_filter = filter::Targets::new();
+    for prefix in &targets {
+        target_filter = target_filter.with_target(prefix.clone(), filter::LevelFilter::TRACE);
+    }
+
+    let layer = fmt::layer()
+        .with_writer(file_rotate)
+        .with_line_number(true)
+        .with_target(true)
+        .with_ansi(false)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .with_filter(target_filter);
+
+    Ok(Some(Box::new(layer)))
 }
 
 #[cfg(target_os = "windows")]
@@ -204,7 +274,7 @@ pub fn init_logger_for_test() {
 mod test {
     #[test]
     fn log_can_be_initialized() {
-        let result = super::init("test", true);
+        let result = super::init("test", true, None);
         assert!(result.is_ok());
     }
 }

--- a/crates/swbus-actor/src/state/outgoing.rs
+++ b/crates/swbus-actor/src/state/outgoing.rs
@@ -59,7 +59,7 @@ impl Outgoing {
     /// Actor logic succeeded, so send out messages.
     pub(crate) async fn send_queued_messages(&mut self) {
         for msg in self.queued_messages.drain(..) {
-            debug!("Sending message: {msg:?}");
+            debug!(target="hamgrd-recorder", "Sending message: {msg:?}");
             self.swbus_client
                 .send_raw(msg.swbus_message.clone())
                 .await

--- a/crates/swbus-actor/src/state/outgoing.rs
+++ b/crates/swbus-actor/src/state/outgoing.rs
@@ -59,7 +59,7 @@ impl Outgoing {
     /// Actor logic succeeded, so send out messages.
     pub(crate) async fn send_queued_messages(&mut self) {
         for msg in self.queued_messages.drain(..) {
-            debug!(target="hamgrd-recorder", "Sending message: {msg:?}");
+            debug!(target:"hamgrd-recorder", "Sending message: {msg:?}");
             self.swbus_client
                 .send_raw(msg.swbus_message.clone())
                 .await

--- a/crates/swbusd/src/main.rs
+++ b/crates/swbusd/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use sonic_common::log;
+use sonic_common::log::{self, FileLogConfig};
 use swbus_config::{swbus_config_from_db, swbus_config_from_yaml};
 use swbus_core::mux::service::SwbusServiceHost;
 use tracing::info;
@@ -20,7 +20,16 @@ struct Args {
 async fn main() {
     let args = Args::parse();
 
-    if let Err(e) = log::init("swbusd", true) {
+    if let Err(e) = log::init(
+        "swbusd",
+        true,
+        Some(FileLogConfig {
+            log_file_path: "/var/log/dash-ha/swbusd.rec".to_string(),
+            max_file_size_bytes: 1 << 26,
+            max_file_count: usize::MAX,
+            targets: vec!["swbus_actor::driver".to_string()],
+        }),
+    ) {
         eprintln!("Failed to initialize logging: {e}");
     }
     info!("Starting swbusd");

--- a/crates/swbusd/src/main.rs
+++ b/crates/swbusd/src/main.rs
@@ -20,16 +20,7 @@ struct Args {
 async fn main() {
     let args = Args::parse();
 
-    if let Err(e) = log::init(
-        "swbusd",
-        true,
-        Some(FileLogConfig {
-            log_file_path: "/var/log/dash-ha/swbusd.rec".to_string(),
-            max_file_size_bytes: 1 << 26,
-            max_file_count: usize::MAX,
-            targets: vec!["swbus_actor::driver".to_string()],
-        }),
-    ) {
+    if let Err(e) = log::init("swbusd", true, None) {
         eprintln!("Failed to initialize logging: {e}");
     }
     info!("Starting swbusd");

--- a/crates/swbusd/src/main.rs
+++ b/crates/swbusd/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use sonic_common::log::{self, FileLogConfig};
+use sonic_common::log;
 use swbus_config::{swbus_config_from_db, swbus_config_from_yaml};
 use swbus_core::mux::service::SwbusServiceHost;
 use tracing::info;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**

Add a dedicated always-on logging file for swbusd under /var/log/dash-ha/.
The log file is named after swbusd.rec.X with logrotate and compression.

**Why I did it**

For easy debugging swbusd communication.

**How I verified it**

**Details if related**