### PR TITLE
Fix endianess mismatch.

### DIFF
--- a/crates/hamgrd/src/actors/test.rs
+++ b/crates/hamgrd/src/actors/test.rs
@@ -486,7 +486,7 @@ pub fn string_to_ip(s: String) -> Option<IpAddress> {
     }
     if let Ok(v4) = s.parse::<std::net::Ipv4Addr>() {
         Some(IpAddress {
-            ip: Some(Ip::Ipv4(u32::from(v4))),
+            ip: Some(Ip::Ipv4(u32::from(v4).to_be())),
         })
     } else if let Ok(v6) = s.parse::<std::net::Ipv6Addr>() {
         Some(IpAddress {

--- a/crates/sonic-dash-api-proto/src/lib.rs
+++ b/crates/sonic-dash-api-proto/src/lib.rs
@@ -17,7 +17,7 @@ pub mod types {
 
 pub fn ip_to_string(ip: &IpAddress) -> String {
     match &ip.ip {
-        Some(Ip::Ipv4(addr)) => std::net::Ipv4Addr::from(*addr).to_string(),
+        Some(Ip::Ipv4(addr)) => std::net::Ipv4Addr::from(u32::from_be(*addr)).to_string(),
         Some(Ip::Ipv6(addr)) => {
             use std::net::Ipv6Addr;
             let bytes: [u8; 16] = addr.clone().try_into().unwrap_or([0; 16]);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**
Change endianess to BE to properly parse ipv4 address received from sonic-mgmt/controller.
signoff: dypeters@cisco.com

**Why I did it**
ipv4 addresses received from sonic-mgmt (socket.htonl(int(ip_addr))) were being processing in reverse order.

**How I verified it**
Ran HA sonic-mgmt test and now the address is being programmed correctly.

**Details if related**