### PR TITLE
Allow driver's maintenance loop to return

### DIFF
--- a/crates/swbus-actor/src/driver.rs
+++ b/crates/swbus-actor/src/driver.rs
@@ -42,7 +42,9 @@ impl<A: Actor> ActorDriver<A> {
 
         loop {
             tokio::select! {
-                _ = self.state.outgoing.drive_maintenance_loop() => unreachable!("drive_maintenance_loop never returns"),
+                _ = self.state.outgoing.drive_maintenance_loop() => {
+                    debug!("Nothing to be done in maintenance loop.")
+                },
                 maybe_msg = self.swbus_edge.recv() => {
                     if let Some(maybe_msg) = maybe_msg {
                         self.handle_swbus_message(maybe_msg).await;

--- a/crates/swbus-actor/src/state/outgoing.rs
+++ b/crates/swbus-actor/src/state/outgoing.rs
@@ -149,8 +149,7 @@ impl Outgoing {
             // Drain delayed messages whose send time has arrived
             if !self.queued_messages.is_empty() {
                 self.send_queued_messages().await;
-            }
-            else if self.unacked_messages.is_empty() {
+            } else if self.unacked_messages.is_empty() {
                 // if both queued messages and unacked messages queues are empty
                 // there is nothing to do maintenance, we will return to check if
                 // the actor is marked as deleted

--- a/crates/swbus-actor/src/state/outgoing.rs
+++ b/crates/swbus-actor/src/state/outgoing.rs
@@ -150,6 +150,12 @@ impl Outgoing {
             if !self.queued_messages.is_empty() {
                 self.send_queued_messages().await;
             }
+            else if self.unacked_messages.is_empty() {
+                // if both queued messages and unacked messages queues are empty
+                // there is nothing to do maintenance, we will return to check if
+                // the actor is marked as deleted
+                return;
+            }
 
             // Resend unacked messages periodically
             let now = SystemTime::now();


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**

Allow the drive_maintenance_loop function to return when the queued messages queue and unacked messages queue are both empty.

**Why I did it**

Before this change, if the Actor has some unacked messages held in the queue and these unacked messages never gets replied, the Actor cannot be deleted even though the the unacked messages will be dropped. This is because the Actor only could exit when the message reception branch won the tokio::select. If there is no messages being received, the actor is stuck since neither drive_maintenance_loop and message reception branch returns.

**How I verified it**

Run sonic-mgmt tests and ensure the actors are deleted afterwards

**Details if related**