### PR TITLE
Add brainsplit_recovered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,7 +215,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.2",
  "object",
  "rustc-demangle",
 ]
@@ -488,6 +494,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,10 +661,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
+name = "file-rotate"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3ed82142801f5b1363f7d463963d114db80f467e860b1cd82228eaebc627a0"
+dependencies = [
+ "chrono",
+ "flate2",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.9",
+]
 
 [[package]]
 name = "fnv"
@@ -1241,7 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1312,6 +1347,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1900,6 +1945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +1981,7 @@ version = "0.1.0"
 dependencies = [
  "better-panic",
  "color-eyre",
+ "file-rotate",
  "human-panic",
  "lazy_static",
  "pretty_assertions",

--- a/crates/hamgrd/src/actors/ha_scope/dpu.rs
+++ b/crates/hamgrd/src/actors/ha_scope/dpu.rs
@@ -204,6 +204,7 @@ impl DpuHaScopeActor {
 
         let mut activate_role_requested = false;
         let mut flow_reconcile_requested = false;
+        let mut brainsplit_recovered = false;
         let approved_ops = dash_ha_scope_config.approved_pending_operation_ids.clone();
         if !approved_ops.is_empty() {
             let pending_operations = self.base.get_pending_operations(internal, None)?;
@@ -223,7 +224,7 @@ impl DpuHaScopeActor {
                         flow_reconcile_requested = true;
                     }
                     "brainsplit_recover" => {
-                        // todo: what's the action here?
+                        brainsplit_recovered = true;
                     }
                     _ => {
                         error!("Unknown operation type {}", op);
@@ -250,6 +251,7 @@ impl DpuHaScopeActor {
             ha_term: "0".to_string(), // TODO: not clear what need to be done for DPU-driven mode
             flow_reconcile_requested: Some(flow_reconcile_requested),
             activate_role_requested: Some(activate_role_requested),
+            brainsplit_recovered: Some(brainsplit_recovered),
         };
 
         let fv = swss_serde::to_field_values(&dash_ha_scope)?;

--- a/crates/hamgrd/src/actors/ha_scope/mod.rs
+++ b/crates/hamgrd/src/actors/ha_scope/mod.rs
@@ -317,7 +317,8 @@ mod test {
                             "vip_v4": ha_set_obj.vip_v4.clone(),
                             "vip_v6": ha_set_obj.vip_v6.clone(),
                             "activate_role_requested": "false",
-                            "flow_reconcile_requested": "false"
+                            "flow_reconcile_requested": "false",
+                            "brainsplit_recovered": "false"
                         },
                         },
                         addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge()) },
@@ -352,7 +353,8 @@ mod test {
                             "vip_v4": ha_set_obj.vip_v4.clone(),
                             "vip_v6": ha_set_obj.vip_v6.clone(),
                             "activate_role_requested": "false",
-                            "flow_reconcile_requested": "false"
+                            "flow_reconcile_requested": "false",
+                            "brainsplit_recovered": "false"
                         },
                         },
                         addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())  },
@@ -377,7 +379,12 @@ mod test {
             let db = crate::db_for_table::<NpuDashHaScopeState>().await.unwrap();
             let table = Table::new(db, NpuDashHaScopeState::table_name()).unwrap();
             let npu_ha_scope_state: NpuDashHaScopeState = swss_serde::from_table(&table, &scope_id_in_state).unwrap();
-            let op_id = npu_ha_scope_state.pending_operation_ids.unwrap().pop().unwrap();
+            let op_id = npu_ha_scope_state
+                .pending_operation_ids
+                .as_ref()
+                .and_then(|ids| ids.first())
+                .cloned()
+                .unwrap();
 
             // continue the test to activate the role
             let mut npu_ha_scope_state4 = npu_ha_scope_state3.clone();
@@ -418,7 +425,8 @@ mod test {
                             "vip_v4": ha_set_obj.vip_v4.clone(),
                             "vip_v6": ha_set_obj.vip_v6.clone(),
                             "activate_role_requested": "true",
-                            "flow_reconcile_requested": "false"
+                            "flow_reconcile_requested": "false",
+                            "brainsplit_recovered": "false"
                         },
                         },
                         addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())
@@ -454,7 +462,8 @@ mod test {
                             "vip_v4": ha_set_obj.vip_v4.clone(),
                             "vip_v6": ha_set_obj.vip_v6.clone(),
                             "activate_role_requested": "false",
-                            "flow_reconcile_requested": "false"
+                            "flow_reconcile_requested": "false",
+                            "brainsplit_recovered": "false"
                         },
                         },
                         addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())
@@ -491,7 +500,8 @@ mod test {
                             "vip_v4": ha_set_obj.vip_v4.clone(),
                             "vip_v6": ha_set_obj.vip_v6.clone(),
                             "activate_role_requested": "false",
-                            "flow_reconcile_requested": "false"
+                            "flow_reconcile_requested": "false",
+                            "brainsplit_recovered": "false"
                         },
                         },
                         addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())
@@ -516,6 +526,142 @@ mod test {
                 recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &scope_id), data: { "active": false }, addr: runtime.sp(VDpuActor::name(), &vdpu0_id) },
                 recv! { key: ActorRegistration::msg_key(RegistrationType::HaSetState, &scope_id), data: { "active": false }, addr: runtime.sp(HaSetActor::name(), &ha_set_id) },
 
+            ];
+
+            test::run_commands(&runtime, runtime.sp(HaScopeActor::name(), &scope_id), &commands).await;
+            if tokio::time::timeout(Duration::from_secs(3), handle).await.is_err() {
+                panic!("timeout waiting for actor to terminate");
+            }
+        }
+
+        #[tokio::test]
+        async fn ha_scope_brainsplit_recovery_approval_sets_recovered_flag() {
+            sonic_common::log::init_logger_for_test();
+            let _redis = Redis::start_config_db();
+            let runtime = test::create_actor_runtime(24, "10.0.24.0", "10:0:24::").await;
+
+            let (ha_set_id, ha_set_obj) = make_dpu_scope_ha_set_obj(24, 0);
+            let dpu_mon = make_dpu_pmon_state(true);
+            let bfd_state = make_dpu_bfd_state(Vec::new(), Vec::new());
+            let dpu0 = make_local_dpu_actor_state(24, 0, true, Some(dpu_mon), Some(bfd_state));
+            let dpu1 = make_remote_dpu_actor_state(25, 0);
+            let (vdpu0_id, vdpu0_state_obj) = make_vdpu_actor_state(true, &dpu0);
+            let (vdpu1_id, _vdpu1_state_obj) = make_vdpu_actor_state(true, &dpu1);
+
+            let mut dpu_ha_scope_state = make_dpu_ha_scope_state("dead");
+            dpu_ha_scope_state.brainsplit_recover_pending = true;
+            dpu_ha_scope_state.last_updated_time = now_in_millis();
+
+            let mut npu_ha_scope_state = make_npu_ha_scope_state(&vdpu0_state_obj, &ha_set_obj);
+            update_npu_ha_scope_state_by_dpu_scope_state(&mut npu_ha_scope_state, &dpu_ha_scope_state, "active");
+            update_npu_ha_scope_state_pending_ops(
+                &mut npu_ha_scope_state,
+                vec![("1".to_string(), "brainsplit_recover".to_string())],
+            );
+            let npu_ha_scope_state_fvs = to_field_values(&npu_ha_scope_state).unwrap();
+
+            let scope_id = format!("{vdpu0_id}:{ha_set_id}");
+            let scope_id_in_state = format!("{vdpu0_id}|{ha_set_id}");
+            let ha_scope_actor = HaScopeActor::new(scope_id.clone()).unwrap();
+            let handle = runtime.spawn(ha_scope_actor, HaScopeActor::name(), &scope_id);
+
+            #[rustfmt::skip]
+            let commands = [
+                send! { key: HaScopeConfig::table_name(), data: { "key": &scope_id, "operation": "Set",
+                        "field_values": {"json": format!(r#"{{"version":"1","disabled":false,"desired_ha_state":{},"owner":{},"ha_set_id":"{ha_set_id}","approved_pending_operation_ids":[]}}"#, DesiredHaState::Active as i32, HaOwner::Dpu as i32)},
+                        },
+                        addr: crate::common_bridge_sp::<HaScopeConfig>(&runtime.get_swbus_edge()) },
+
+                recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &scope_id), data: { "active": true }, addr: runtime.sp(VDpuActor::name(), &vdpu0_id) },
+                recv! { key: ActorRegistration::msg_key(RegistrationType::HaSetState, &scope_id), data: { "active": true }, addr: runtime.sp(HaSetActor::name(), &ha_set_id) },
+                recv!( key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Dpu as i32, "new_state": HaState::Unspecified.as_str_name(), "term": "0", "vdpu_id": &vdpu0_id, "peer_vdpu_id": "" }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp"),
+
+                send! { key: VDpuActorState::msg_key(&vdpu0_id), data: vdpu0_state_obj, addr: runtime.sp("vdpu", &vdpu0_id) },
+                send! { key: HaSetActorState::msg_key(&ha_set_id), data: { "up": true, "ha_set": &ha_set_obj, "vdpu_ids": vec![vdpu0_id.clone(), vdpu1_id.clone()], "pinned_vdpu_bfd_probe_states": vec!["".to_string()] }, addr: runtime.sp(HaSetActor::name(), &ha_set_id) },
+
+                recv! { key: &ha_set_id, data: {
+                        "key": &ha_set_id,
+                        "operation": "Set",
+                        "field_values": {
+                            "version": "1",
+                            "ha_role": "active",
+                            "ha_term": "0",
+                            "disabled": "false",
+                            "ha_set_id": &ha_set_id,
+                            "vip_v4": ha_set_obj.vip_v4.clone(),
+                            "vip_v6": ha_set_obj.vip_v6.clone(),
+                            "activate_role_requested": "false",
+                            "flow_reconcile_requested": "false",
+                            "brainsplit_recovered": "false"
+                        },
+                        },
+                        addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge()) },
+
+                send! { key: DpuDashHaScopeState::table_name(), data: {"key": DpuDashHaScopeState::table_name(), "operation": "Set",
+                        "field_values": serde_json::to_value(to_field_values(&dpu_ha_scope_state).unwrap()).unwrap()
+                        }},
+
+                chkdb! { type: NpuDashHaScopeState,
+                        key: &scope_id_in_state, data: npu_ha_scope_state_fvs,
+                        exclude: "pending_operation_ids,pending_operation_list_last_updated_time_in_ms" },
+            ];
+
+            test::run_commands(&runtime, runtime.sp(HaScopeActor::name(), &scope_id), &commands).await;
+
+            let db = crate::db_for_table::<NpuDashHaScopeState>().await.unwrap();
+            let table = Table::new(db, NpuDashHaScopeState::table_name()).unwrap();
+            let npu_ha_scope_state: NpuDashHaScopeState = swss_serde::from_table(&table, &scope_id_in_state).unwrap();
+            let op_id = npu_ha_scope_state
+                .pending_operation_ids
+                .as_ref()
+                .and_then(|ids| ids.first())
+                .cloned()
+                .unwrap();
+
+            let mut expected_npu_ha_scope_state = npu_ha_scope_state.clone();
+            update_npu_ha_scope_state_pending_ops(&mut expected_npu_ha_scope_state, vec![]);
+            let expected_npu_ha_scope_state_fvs = to_field_values(&expected_npu_ha_scope_state).unwrap();
+
+            #[rustfmt::skip]
+            let commands = [
+                send! { key: HaScopeConfig::table_name(), data: { "key": &scope_id, "operation": "Set",
+                        "field_values": {"json": format!(r#"{{"version":"2","disabled":false,"desired_ha_state":{},"owner":{},"ha_set_id":"{ha_set_id}","approved_pending_operation_ids":["{op_id}"]}}"#, DesiredHaState::Active as i32, HaOwner::Dpu as i32)},
+                        },
+                        addr: crate::common_bridge_sp::<HaScopeConfig>(&runtime.get_swbus_edge()) },
+
+                recv! { key: &ha_set_id, data: {
+                        "key": &ha_set_id,
+                        "operation": "Set",
+                        "field_values": {
+                            "version": "2",
+                            "ha_role": "active",
+                            "ha_term": "0",
+                            "disabled": "false",
+                            "ha_set_id": &ha_set_id,
+                            "vip_v4": ha_set_obj.vip_v4.clone(),
+                            "vip_v6": ha_set_obj.vip_v6.clone(),
+                            "activate_role_requested": "false",
+                            "flow_reconcile_requested": "false",
+                            "brainsplit_recovered": "true"
+                        },
+                        },
+                        addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge()) },
+
+                chkdb! { type: NpuDashHaScopeState,
+                        key: &scope_id_in_state, data: expected_npu_ha_scope_state_fvs,
+                        exclude: "pending_operation_list_last_updated_time_in_ms" },
+
+                send! { key: HaScopeConfig::table_name(), data: { "key": &scope_id, "operation": "Del",
+                        "field_values": {"json": format!(r#"{{"version":"2","disabled":false,"desired_ha_state":{},"owner":{},"ha_set_id":"{ha_set_id}","approved_pending_operation_ids":[]}}"#, DesiredHaState::Active as i32, HaOwner::Dpu as i32)},
+                        },
+                        addr: crate::common_bridge_sp::<HaScopeConfig>(&runtime.get_swbus_edge()) },
+
+                chkdb! { type: NpuDashHaScopeState, key: &scope_id_in_state, nonexist },
+
+                recv! { key: &ha_set_id, data: { "key": &ha_set_id, "operation": "Del", "field_values": {} },
+                        addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge()) },
+                recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &scope_id), data: { "active": false }, addr: runtime.sp(VDpuActor::name(), &vdpu0_id) },
+                recv! { key: ActorRegistration::msg_key(RegistrationType::HaSetState, &scope_id), data: { "active": false }, addr: runtime.sp(HaSetActor::name(), &ha_set_id) },
             ];
 
             test::run_commands(&runtime, runtime.sp(HaScopeActor::name(), &scope_id), &commands).await;

--- a/crates/hamgrd/src/actors/ha_scope/npu.rs
+++ b/crates/hamgrd/src/actors/ha_scope/npu.rs
@@ -1890,6 +1890,7 @@ impl NpuHaScopeActor {
                 .unwrap_or("0".to_string()),
             flow_reconcile_requested: None,
             activate_role_requested: None,
+            brainsplit_recovered: None,
         };
 
         let fv = swss_serde::to_field_values(&dash_ha_scope)?;

--- a/crates/hamgrd/src/db_structs.rs
+++ b/crates/hamgrd/src/db_structs.rs
@@ -389,6 +389,7 @@ pub struct DashHaScopeTable {
     pub vip_v6: Option<String>,
     pub flow_reconcile_requested: Option<bool>,
     pub activate_role_requested: Option<bool>,
+    pub brainsplit_recovered: Option<bool>,
 }
 
 /// <https://github.com/sonic-net/SONiC/blob/master/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md#2342-ha-scope-state>


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**
Adding the brainsplit_recovered flag as decribed in: https://github.com/sonic-net/SONiC/blob/1670e1f7a0c66b022e117d33c3f0697c22292bf5/doc/smart-switch/high-availability/smart-switch-ha-detailed-design.md

**Why I did it**
DPU dash orchagent will use this flag when brainsplit op ID is approve by controller.

**How I verified it**
Ran brainsplit scenario and inspected the DB.

Before approving brainsplit_recover pending op:
```
admin@MtFuji-dut02:~$ redis-cli --raw -h 169.254.200.254 -p 6381 -n 15 HGETALL DASH_HA_SCOPE_TABLE:haset0_0
ha_set_id
haset0_0
ha_term
0
vip_v4
3.2.1.0
**brainsplit_recovered
false**
disabled
false
version
3
flow_reconcile_requested
false
vip_v6
3:2::1:0
ha_role
standby
activate_role_requested
false
```


After approving brainsplit_recover pending op:
```
admin@MtFuji-dut02:~$ redis-cli --raw -h 169.254.200.254 -p 6381 -n 15 HGETALL DASH_HA_SCOPE_TABLE:haset0_0
vip_v4
3.2.1.0
vip_v6
3:2::1:0
disabled
false
flow_reconcile_requested
false
ha_term
0
ha_role
standby
**brainsplit_recovered
true**
activate_role_requested
false
version
3
ha_set_id
haset0_0
```

**Details if related**