### PR TITLE
Add 4 common AI agent skills for build/test/deployment

### DIFF
--- a/.github/skills/build-dash-ha-container/SKILL.md
+++ b/.github/skills/build-dash-ha-container/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: build-dash-ha-container
+description: 'Create the sonic-dash-ha Docker build container from scratch and verify the repo compiles. Use when: setting up a new build container, bootstrapping the dash-ha dev environment, "create the build container", "set up sonic-dash-ha container", installing build dependencies, building libswsscommon.'
+argument-hint: 'Optional: container name, repo path, or base image to override defaults'
+---
+
+# Build the sonic-dash-ha Container
+
+## When to Use
+- Setting up a fresh local build environment for sonic-dash-ha
+- The `sonic-dash-ha` build container does not exist yet (check with `docker ps -a`)
+- Onboarding a new developer who needs a reproducible build container
+
+This skill **creates** the build container. To compile/test in an existing
+container, use the `build-test-dash-ha` skill instead.
+
+## Prerequisites
+- Docker installed and running (`docker --version`)
+- Network access to pull `ubuntu:22.04`, clone `sonic-swss-common`, and fetch crates
+
+## Default Configuration
+
+| Parameter | Default Value |
+|-----------|--------------|
+| Container name | `sonic-dash-ha` |
+| Base image | `ubuntu:22.04` |
+| Host repo path | `<path-to-sonic-dash-ha>` |
+| Container repo path | `/sonic-dash-ha` (bind-mounted from host) |
+| swss-common path | `/opt/sonic-swss-common` |
+
+The host repo path is a placeholder — substitute the actual path to the user's
+local sonic-dash-ha checkout. If the user provides a different container name or
+base image, use those instead.
+
+## Procedure
+
+### Step 1: Create the container
+
+Bind-mount the host repo so builds operate on the working tree directly.
+
+```bash
+docker run -d --name sonic-dash-ha --hostname sonic-dash-ha \
+  -v <path-to-sonic-dash-ha>:/sonic-dash-ha \
+  -w /sonic-dash-ha ubuntu:22.04 sleep infinity
+docker ps --filter name=sonic-dash-ha --format '{{.Names}}\t{{.Status}}'
+```
+
+If a container with the same name already exists, stop and tell the user.
+Do not delete it without confirmation.
+
+### Step 2: Install system build dependencies
+
+This includes the Rust/protobuf toolchain, the full `sonic-swss-common` build
+dependency chain, **and `libclang-dev`/`clang`** (required by `bindgen` in the
+`swss-common` crate — easy to miss).
+
+```bash
+docker exec -e DEBIAN_FRONTEND=noninteractive sonic-dash-ha bash -c "apt-get update && apt-get install -y --no-install-recommends \
+  build-essential make protobuf-compiler libprotobuf-dev curl git ca-certificates \
+  pkg-config libssl-dev autoconf automake libtool libhiredis-dev \
+  libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev swig4.0 \
+  libboost-serialization-dev libboost-dev uuid-dev libzmq3-dev libgtest-dev libgmock-dev \
+  cmake nlohmann-json3-dev python3 python3-dev python-is-python3 cython3 \
+  libclang-dev clang"
+```
+
+### Step 3: Install the Rust toolchain
+
+```bash
+docker exec sonic-dash-ha bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable"
+docker exec sonic-dash-ha /root/.cargo/bin/rustc --version
+```
+
+### Step 4: Build libswsscommon (with the redisapi.h patch)
+
+Clone `sonic-swss-common`, apply the README patch that redirects the hard-coded
+Lua script path, configure **with YANG modules disabled** (avoids the
+`sonic_yang`/libyang dependency, which isn't needed for the FFI bridge), then build.
+
+```bash
+docker exec sonic-dash-ha bash -c "cd /opt && git clone --depth 1 https://github.com/sonic-net/sonic-swss-common && \
+  sed -i 's#return readTextFile(\"/usr/share/swss/\" + path);#return readTextFile(\"/opt/sonic-swss-common/common/\" + path);#' /opt/sonic-swss-common/common/redisapi.h"
+
+docker exec sonic-dash-ha bash -c "cd /opt/sonic-swss-common && ./autogen.sh && \
+  ./configure --enable-yangmodules=no && make -j \$(nproc)"
+```
+
+Verify the shared library was produced:
+
+```bash
+docker exec sonic-dash-ha bash -c "ls -l /opt/sonic-swss-common/common/.libs/libswsscommon.so"
+```
+
+### Step 5: Persist build environment variables
+
+Write the env vars to a profile script and source it from `.bashrc` so every
+`docker exec bash -l` session has them.
+
+```bash
+docker exec sonic-dash-ha bash -c 'printf "export PATH=\"/root/.cargo/bin:\$PATH\"\nexport SWSS_COMMON_REPO=\"/opt/sonic-swss-common\"\nexport LD_LIBRARY_PATH=\"/opt/sonic-swss-common/common/.libs\"\n" > /etc/profile.d/dash-ha.sh; \
+  grep -q dash-ha.sh /root/.bashrc || echo "source /etc/profile.d/dash-ha.sh" >> /root/.bashrc'
+```
+
+### Step 6: Verify the repo builds
+
+```bash
+docker exec sonic-dash-ha bash -lc "cd /sonic-dash-ha && cargo build --workspace 2>&1 | tail -n 30"
+```
+
+A successful run ends with `Finished \`dev\` profile ... target(s)` and exit code 0,
+compiling all crates including `hamgrd`, `swbusd`, and `swss-common-bridge`.
+
+## Gotchas
+
+- **libclang**: The `swss-common` crate uses `bindgen`, which needs `libclang-dev`.
+  Without it the build fails with "Unable to find libclang". Not mentioned in the README.
+- **YANG modules**: The default `sonic-swss-common` build enables YANG modules and
+  requires the `sonic_yang` Python module + libyang. Use `--enable-yangmodules=no`
+  to skip that dependency chain — the FFI bridge does not need it.
+- **Python required by configure**: `sonic-swss-common`'s `configure` aborts without
+  a Python interpreter; install `python3`/`python3-dev` before configuring.
+- **redisapi.h patch**: The hard-coded `/usr/share/swss/` path must be patched to the
+  clone location, or runtime Lua script loading breaks. See the README for details.
+- **Bind mount vs. docker cp**: This skill bind-mounts the host repo so edits are
+  immediately visible. The `build-test-dash-ha` skill instead copies a fresh tree in;
+  pick whichever workflow the user expects.
+- **Base image**: `ubuntu:22.04` (jammy) provides compatible `protoc`, boost, and
+  libclang-14 versions. Newer bases may pull incompatible toolchain versions.

--- a/.github/skills/build-test-dash-ha/SKILL.md
+++ b/.github/skills/build-test-dash-ha/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: build-test-dash-ha
+description: 'Copy dash-ha repo into build container and run compilation checks and unit tests. Use when: compile and test in sonic-dash-ha repo.'
+argument-hint: 'Optional: specific make targets (e.g. ci-build, ci-test, ci-lint) or crate names to test'
+---
+
+# Build & Test in dash-ha Container
+
+## When to Use
+- After code changes in sonic-dash-ha, to verify compilation inside the build container
+- To run unit tests in the same environment as CI
+- To check for warnings, clippy lints, or formatting issues before pushing
+- When the user says "build in container", "test in container", or "CI check"
+
+## Prerequisites
+- The `sonic-dash-ha` Docker build container must be running locally (check with `docker ps`)
+
+## Default Configuration
+
+| Parameter | Default Value |
+|-----------|--------------|
+| Build container | `sonic-dash-ha` |
+| Host repo path | `<path-to-sonic-dash-ha>` |
+| Container repo path | `/sonic-dash-ha` |
+
+The host repo path is a placeholder — substitute the actual path to the user's
+local sonic-dash-ha checkout.
+
+## Procedure
+
+### Step 1: Verify the build container is running
+
+```bash
+docker ps --filter name=sonic-dash-ha --format '{{.Names}}'
+```
+
+If the container is not running, stop and tell the user. Do not attempt to start it.
+
+### Step 2: Copy repo into build container
+
+```bash
+docker exec sonic-dash-ha bash -c "rm -rf /sonic-dash-ha" && \
+docker cp <path-to-sonic-dash-ha> sonic-dash-ha:/sonic-dash-ha
+```
+
+This removes the old source tree and copies a fresh one. The cargo build cache under `target/` is preserved for incremental builds.
+
+### Step 3: Run compilation check
+
+```bash
+docker exec sonic-dash-ha bash -c "cd /sonic-dash-ha && cargo build --workspace --all-features 2>&1"
+```
+
+If the user asks for a **CI-grade** build (strict, deny warnings), use:
+
+```bash
+docker exec sonic-dash-ha bash -c "cd /sonic-dash-ha && RUSTFLAGS='--deny warnings' cargo build --workspace --all-features 2>&1"
+```
+
+Check the output for errors. If compilation fails, show the errors and stop — do not proceed to tests.
+
+### Step 4: Run unit tests
+
+```bash
+docker exec sonic-dash-ha bash -c "cd /sonic-dash-ha && cargo test --workspace --all-features 2>&1"
+```
+
+To test a **specific crate**:
+
+```bash
+docker exec sonic-dash-ha bash -c "cd /sonic-dash-ha && cargo test -p <crate-name> 2>&1"
+```
+
+Report the test summary (number of passed/failed tests). If any tests fail, show the failure output.
+
+## Additional Checks (on request)
+
+These are only run when the user explicitly asks, or asks for "full CI" / "ci-all":
+
+### Formatting check
+
+```bash
+docker exec sonic-dash-ha bash -c "cd /sonic-dash-ha && cargo fmt --check --all 2>&1"
+```
+
+### Clippy lint check
+
+```bash
+docker exec sonic-dash-ha bash -c "cd /sonic-dash-ha && cargo clippy --workspace --all-features --no-deps -- --deny 'clippy::all' 2>&1"
+```
+
+### Full CI pipeline
+
+Runs all CI targets sequentially (format, build, doc, lint, test — both debug and release):
+
+```bash
+docker exec sonic-dash-ha bash -c "cd /sonic-dash-ha && make ci-all 2>&1"
+```
+
+**Warning**: This is slow as it builds and tests in both debug and release modes with `cargo clean` between each stage.
+
+## Gotchas
+
+- **Build cache**: Removing the old repo with `rm -rf` and re-copying ensures clean source. The `target/` directory inside the container is *not* preserved across `rm -rf` + `docker cp` since it lives under `/sonic-dash-ha/target/`. For faster incremental builds, consider syncing only changed files instead.
+- **Long output**: Build and test output can be very large. Use `| tail -n 50` if you only need to see the summary, but show full output on failure.
+- **Timeouts**: Use generous timeouts (300s+) for build commands. Full `ci-all` can take much longer.
+- **Release builds**: If the user asks to test release mode, add `--release` to build and test commands.

--- a/.github/skills/deploy-dash-ha/SKILL.md
+++ b/.github/skills/deploy-dash-ha/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: deploy-dash-ha
+description: 'Build dash-ha debian packages and deploy to SONiC switches. Use when: building deb, deploying to switches, installing dash-ha, config reload, dpkg-buildpackage, deploy dash-hadpu containers.'
+argument-hint: 'Optional: switch IPs, credentials, or container names to customize deployment'
+---
+
+# Deploy dash-ha to SONiC Switches
+
+## When to Use
+- After code changes, to build and deploy updated dash-ha binaries
+- When installing dash-ha packages on switches
+
+## Prerequisites
+- The `sonic-dash-ha` Docker build container must be running locally (check with `docker ps`)
+- Target switches must be reachable via SSH
+- `sshpass` must be installed on the dev machine
+
+## Default Configuration
+
+| Parameter | Default Value |
+|-----------|--------------|
+| Build container | `sonic-dash-ha` |
+| Host repo path | `<path-to-sonic-dash-ha>` |
+| Container repo path | `/sonic-dash-ha` |
+| Switch IPs | `<switch_ip>` (one or more) |
+| Switch username | `admin` |
+| Target containers | `dash-hadpu0`, `dash-hadpu1`, `dash-hadpu2`, `dash-hadpu3` |
+| Packages | `dash-ha_1.0.0_amd64.deb`, `dash-ha-dbgsym_1.0.0_amd64.deb` |
+
+The values above are placeholders. Ask the user (or read from their environment)
+for the host repo path, switch IPs, username, and container names, and use those instead.
+
+## Procedure
+
+### Step 0: Ask for switch password
+
+Before starting deployment, **always** use the ask-questions tool to prompt the user for the switch password. Never store or hardcode the password. Use the password for all subsequent `sshpass` commands.
+
+### Step 1: Copy repo into build container
+
+```bash
+docker exec sonic-dash-ha bash -c "rm -rf /sonic-dash-ha" && \
+docker cp <path-to-sonic-dash-ha> sonic-dash-ha:/sonic-dash-ha
+```
+
+### Step 2: Build debian packages
+
+```bash
+docker exec sonic-dash-ha bash -c "cd /sonic-dash-ha && dpkg-buildpackage -us -uc -b 2>&1" | tail -5
+```
+
+Verify the output ends with `dpkg-buildpackage: info: binary-only upload`. If the build fails, show the full error output.
+
+### Step 3: Extract debs and SCP to switches
+
+```bash
+# Extract from container
+docker cp sonic-dash-ha:/dash-ha_1.0.0_amd64.deb /tmp/dash-ha_1.0.0_amd64.deb
+docker cp sonic-dash-ha:/dash-ha-dbgsym_1.0.0_amd64.deb /tmp/dash-ha-dbgsym_1.0.0_amd64.deb
+
+# SCP to all switches
+sshpass -p '<password>' scp -o StrictHostKeyChecking=no \
+  /tmp/dash-ha_1.0.0_amd64.deb /tmp/dash-ha-dbgsym_1.0.0_amd64.deb \
+  admin@<switch_ip>:/tmp/
+```
+
+### Step 4: Install in dash-hadpu containers on each switch
+
+For each switch, run:
+
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no admin@<switch_ip> \
+  'for i in 0 1 2 3; do
+    echo "=== dash-hadpu$i ===";
+    sudo docker cp /tmp/dash-ha_1.0.0_amd64.deb dash-hadpu$i:/dash-ha_1.0.0_amd64.deb;
+    sudo docker cp /tmp/dash-ha-dbgsym_1.0.0_amd64.deb dash-hadpu$i:/dash-ha-dbgsym_1.0.0_amd64.deb;
+    sudo docker exec dash-hadpu$i dpkg -i /dash-ha_1.0.0_amd64.deb /dash-ha-dbgsym_1.0.0_amd64.deb;
+  done'
+```
+
+**Important**: Copy files to `/` inside the containers, not `/tmp/` — the containers use a tmpfs for `/tmp/` that doesn't persist across `docker cp` and `docker exec`.
+
+Verify each container shows `Setting up dash-ha (1.0.0) ...` and `Setting up dash-ha-dbgsym (1.0.0) ...`.
+
+### Step 5: Config reload on each switch
+
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no admin@<switch_ip> \
+  'sudo config reload -y 2>&1'
+```
+
+Verify output shows `Released lock on /etc/sonic/reload.lock`.
+
+## Gotchas
+
+- **Container `/tmp/` is tmpfs**: Files copied via `docker cp` to `/tmp/` inside dash-hadpu containers are not visible to `docker exec`. Copy to `/` instead (e.g., `/dash-ha_1.0.0_amd64.deb`).
+- **Build cache**: The build container preserves cargo cache from previous builds under `/sonic-dash-ha/target/`, so incremental builds are fast. Removing the old repo with `rm -rf` and re-copying ensures clean source while preserving no stale build artifacts.
+- **Debug symbols**: Always install `dash-ha-dbgsym` alongside `dash-ha` unless explicitly told otherwise.
+- **Config reload timeout**: The `config reload` command can take a while. Use a generous timeout (300s+).

--- a/.github/skills/deploy-dash-ha/SKILL.md
+++ b/.github/skills/deploy-dash-ha/SKILL.md
@@ -13,7 +13,11 @@ argument-hint: 'Optional: switch IPs, credentials, or container names to customi
 ## Prerequisites
 - The `sonic-dash-ha` Docker build container must be running locally (check with `docker ps`)
 - Target switches must be reachable via SSH
-- `sshpass` must be installed on the dev machine
+- SSH access to the switches is configured. **Strongly preferred:** key-based
+  authentication (an SSH public key installed on each switch, e.g. via
+  `ssh-copy-id admin@<switch_ip>`). If only password auth is available, `ssh`/`scp`
+  will prompt for the password interactively — the user types it directly into the
+  terminal.
 
 ## Default Configuration
 
@@ -32,9 +36,13 @@ for the host repo path, switch IPs, username, and container names, and use those
 
 ## Procedure
 
-### Step 0: Ask for switch password
+### Step 0: Confirm SSH access
 
-Before starting deployment, **always** use the ask-questions tool to prompt the user for the switch password. Never store or hardcode the password. Use the password for all subsequent `sshpass` commands.
+Use key-based SSH authentication wherever possible (install your public key on each
+switch with `ssh-copy-id admin@<switch_ip>`). **Never** pass passwords on the command
+line (no `sshpass`, no `-p` flags) and never store or hardcode credentials. If a switch
+only supports password auth, run the `ssh`/`scp` commands below as-is and let the user
+type the password directly into the terminal when prompted.
 
 ### Step 1: Copy repo into build container
 
@@ -59,7 +67,7 @@ docker cp sonic-dash-ha:/dash-ha_1.0.0_amd64.deb /tmp/dash-ha_1.0.0_amd64.deb
 docker cp sonic-dash-ha:/dash-ha-dbgsym_1.0.0_amd64.deb /tmp/dash-ha-dbgsym_1.0.0_amd64.deb
 
 # SCP to all switches
-sshpass -p '<password>' scp -o StrictHostKeyChecking=no \
+scp -o StrictHostKeyChecking=no \
   /tmp/dash-ha_1.0.0_amd64.deb /tmp/dash-ha-dbgsym_1.0.0_amd64.deb \
   admin@<switch_ip>:/tmp/
 ```
@@ -69,7 +77,7 @@ sshpass -p '<password>' scp -o StrictHostKeyChecking=no \
 For each switch, run:
 
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no admin@<switch_ip> \
+ssh -o StrictHostKeyChecking=no admin@<switch_ip> \
   'for i in 0 1 2 3; do
     echo "=== dash-hadpu$i ===";
     sudo docker cp /tmp/dash-ha_1.0.0_amd64.deb dash-hadpu$i:/dash-ha_1.0.0_amd64.deb;
@@ -85,7 +93,7 @@ Verify each container shows `Setting up dash-ha (1.0.0) ...` and `Setting up das
 ### Step 5: Config reload on each switch
 
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no admin@<switch_ip> \
+ssh -o StrictHostKeyChecking=no admin@<switch_ip> \
   'sudo config reload -y 2>&1'
 ```
 

--- a/.github/skills/sonic-mgmt-int-testing/SKILL.md
+++ b/.github/skills/sonic-mgmt-int-testing/SKILL.md
@@ -34,7 +34,11 @@ Before starting, use the ask-questions tool to collect any missing information:
 - **Test file** — the pytest file to run (e.g., `ha/test_ha_planned_shutdown.py`)
 - **DUT hostnames** — comma-separated DUT names (e.g., `<dut-hostname-1>,<dut-hostname-2>`)
 - **DPU hostnames** — comma-separated DPU names (e.g., `<dut-hostname-1>-dpu-0,<dut-hostname-2>-dpu-0`)
-- **Switch password** — Prompt the user to type it directly into the terminal when needed. **Never** route passwords through ask-questions.
+- **Switch authentication** — Use key-based SSH where possible (install your public
+  key on the switch with `ssh-copy-id admin@<switch_ip>`). If only password auth is
+  available, let `ssh` prompt and type the password directly into the terminal. **Never**
+  pass passwords on the command line (no `sshpass`/`-p`) and never route passwords
+  through ask-questions.
 
 Use the defaults above for inventory, testbed name, and other flags unless the user specifies otherwise.
 
@@ -107,17 +111,18 @@ To debug failures, connect to the DUT switches and inspect syslog. First, look u
 grep -A5 '<DUT_HOSTNAME>' /data/sonic-mgmt-int/ansible/<inventory>
 ```
 
-Then SSH to the switch (from the dev machine, not the container) and check syslog:
+Then SSH to the switch (from the dev machine, not the container) and check syslog.
+Use key-based auth if configured; otherwise `ssh` prompts for the password interactively:
 
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no admin@<SWITCH_IP> \
+ssh -o StrictHostKeyChecking=no admin@<SWITCH_IP> \
   "sudo grep -E 'ERR|WARN|CRIT' /var/log/syslog | tail -50"
 ```
 
 For DPU-specific logs (dash-hadpu containers):
 
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no admin@<SWITCH_IP> \
+ssh -o StrictHostKeyChecking=no admin@<SWITCH_IP> \
   "sudo grep 'dash-hadpu0#hamgrd' /var/log/syslog | grep -v DEBUG | tail -30"
 ```
 

--- a/.github/skills/sonic-mgmt-int-testing/SKILL.md
+++ b/.github/skills/sonic-mgmt-int-testing/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: sonic-mgmt-int-testing
+description: 'Run sonic-mgmt-int pytest tests on physical SmartSwitch testbeds and debug failures. Use when: running HA tests, planned shutdown tests, running sonic-mgmt-int tests, checking test logs, debugging test failures on physical switches, analyzing syslog on DUT, run_tests.sh.'
+argument-hint: 'Optional: test file path, testbed name, DUT hostnames, or DPU hostnames'
+---
+
+# sonic-mgmt-int Physical Testbed Testing
+
+Run pytest-based tests from the `sonic-mgmt-int` container against physical SmartSwitch testbeds, then debug failures using test logs and switch syslog.
+
+## When to Use
+- Running HA or SmartSwitch tests on physical testbeds
+- Debugging test failures by checking logs and switch syslog
+- Analyzing XML test results from sonic-mgmt-int
+
+## Default Configuration
+
+| Parameter | Default Value |
+|-----------|--------------|
+| Container name | `sonic-mgmt-int` |
+| Tests directory | `/data/sonic-mgmt-int/tests` |
+| Logs directory | `/data/sonic-mgmt-int/tests/logs` |
+| Inventory files | `../ansible/<inventory>,../ansible/veos` |
+| Testbed name | `<testbed_name>` |
+
+The inventory name and testbed name are placeholders. Ask the user for their
+testbed name and inventory file(s), and use those instead.
+
+## Procedure
+
+### Step 0: Ask for required parameters
+
+Before starting, use the ask-questions tool to collect any missing information:
+- **Test file** — the pytest file to run (e.g., `ha/test_ha_planned_shutdown.py`)
+- **DUT hostnames** — comma-separated DUT names (e.g., `<dut-hostname-1>,<dut-hostname-2>`)
+- **DPU hostnames** — comma-separated DPU names (e.g., `<dut-hostname-1>-dpu-0,<dut-hostname-2>-dpu-0`)
+- **Switch password** — Prompt the user to type it directly into the terminal when needed. **Never** route passwords through ask-questions.
+
+Use the defaults above for inventory, testbed name, and other flags unless the user specifies otherwise.
+
+### Step 1: Enter the sonic-mgmt-int container
+
+```bash
+docker exec -it sonic-mgmt-int bash
+```
+
+All subsequent commands run **inside** this container.
+
+### Step 2: Navigate to the tests directory
+
+```bash
+cd /data/sonic-mgmt-int/tests
+```
+
+### Step 3: Run the test
+
+Use `run_tests.sh` with the collected parameters:
+
+```bash
+./run_tests.sh \
+  -i ../ansible/<inventory>,../ansible/veos \
+  -n <testbed_name> \
+  -e "--disable_loganalyzer --skip_yang --skip_sanity" \
+  -u \
+  -m individual \
+  -d <DUT_HOSTNAMES> \
+  -H <DPU_HOSTNAMES> \
+  -c "<TEST_FILE>"
+```
+
+**Important**: This command can take a long time (10+ minutes). Use a generous timeout or run in async mode so the test can complete without interruption.
+
+### Step 4: Wait for the test to finish
+
+Monitor the terminal output until the test completes. Look for the pytest summary showing passed/failed/error counts.
+
+### Step 5: Check test logs and XML results
+
+After the test finishes, examine the logs directory:
+
+```bash
+ls -lt /data/sonic-mgmt-int/tests/logs/ | head -10
+```
+
+Find the most recent log directory (named by timestamp or test name). Inside it, check:
+
+- **`*.xml`** — JUnit XML results. Parse for `<failure>` and `<error>` elements to identify which tests failed and why.
+- **`*.log`** — Detailed test execution logs. Search for `FAILED`, `ERROR`, `assert`, or exception tracebacks.
+
+```bash
+# Find the latest log directory
+LATEST=$(ls -td /data/sonic-mgmt-int/tests/logs/*/ | head -1)
+
+# Show test results summary from XML
+grep -E 'testcase|failure|error' "$LATEST"/*.xml | head -30
+
+# Show failures from the log
+grep -B5 -A10 'FAILED\|ERROR\|AssertionError' "$LATEST"/*.log | tail -50
+```
+
+### Step 6: Check syslog on the switches
+
+To debug failures, connect to the DUT switches and inspect syslog. First, look up the switch management IPs from the inventory:
+
+```bash
+# Inside sonic-mgmt-int container
+grep -A5 '<DUT_HOSTNAME>' /data/sonic-mgmt-int/ansible/<inventory>
+```
+
+Then SSH to the switch (from the dev machine, not the container) and check syslog:
+
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no admin@<SWITCH_IP> \
+  "sudo grep -E 'ERR|WARN|CRIT' /var/log/syslog | tail -50"
+```
+
+For DPU-specific logs (dash-hadpu containers):
+
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no admin@<SWITCH_IP> \
+  "sudo grep 'dash-hadpu0#hamgrd' /var/log/syslog | grep -v DEBUG | tail -30"
+```
+
+## Gotchas
+
+- **Long test times**: Tests on physical testbeds can take 10-30+ minutes. Always use generous timeouts.
+- **Inventory paths**: The `-i` flag takes comma-separated paths to Ansible inventory directories. The inventory files contain the management IPs for each switch.
+- **`-u` flag**: Passes `--allow-unsorted` to pytest, required for most test runs.
+- **`-m individual`**: Runs tests one at a time instead of in parallel.
+- **`-H` flag**: Specifies DPU hostnames for SmartSwitch HA tests.
+- **Log rotation**: Switch syslogs may rotate. Check `/var/log/syslog.1` if recent entries are missing.
+- **Container syslog**: hamgrd logs inside dash-hadpu containers are forwarded to the host's `/var/log/syslog` prefixed with `dash-hadpuN#hamgrd`.


### PR DESCRIPTION
### Description of PR

Summary:
This PR adds four reusable agent skills under `.github/skills/` to document and automate common sonic-dash-ha development workflows. These skills package the institutional knowledge for building, testing, deploying, and validating dash-ha so that any developer (or coding agent) can reproduce the workflows without re-discovering the setup steps, undocumented dependencies, and environment gotchas.

The skills added are:
- **build-dash-ha-container** — Creates the `sonic-dash-ha` Docker build container from scratch: base image, system build dependencies (including the easy-to-miss `libclang-dev` for bindgen and the full `sonic-swss-common` build chain), Rust toolchain, `libswsscommon` build with the `redisapi.h` patch and `--enable-yangmodules=no`, persisted env vars, and a final `cargo build --workspace` verification.
- **build-test-dash-ha** — Copies the repo into the build container and runs compilation checks, unit tests, and optional CI-grade checks (fmt, clippy, `make ci-all`).
- **deploy-dash-ha** — Builds the dash-ha debian packages and deploys them to SONiC switches' `dash-hadpu*` containers, followed by `config reload`.
- **sonic-mgmt-int-testing** — Runs `sonic-mgmt-int` pytest tests on physical SmartSwitch testbeds and debugs failures via test logs and DUT syslog.

Reviewer entry point: start with `build-dash-ha-container/SKILL.md` (the bootstrap workflow), then the build/deploy/test skills that depend on it. All host-specific values (repo paths, switch IPs, testbed names, hostnames) are parameterized as placeholders so the skills are portable across developer environments.

Fixes # (N/A)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?
Setting up a dash-ha build environment and running the build/deploy/test workflows currently requires tribal knowledge that isn't captured in the README — e.g., `libclang` is needed for the `swss-common` bindgen step, and `sonic-swss-common` must be configured with `--enable-yangmodules=no` to avoid the `sonic_yang`/libyang dependency chain. These skills make the workflows reproducible and self-documenting.

#### How did you do it?
Added four `SKILL.md` files under `.github/skills/`, each with YAML frontmatter (name/description/argument-hint), a "When to Use" section, a default-configuration table, step-by-step procedures, and a "Gotchas" section. Environment-specific details are abstracted into placeholders (`<path-to-sonic-dash-ha>`, `<switch_ip>`, `<testbed_name>`, `<dut-hostname-N>`) so they're generic and reusable by other developers.

#### How did you verify/test it?
The `build-dash-ha-container` procedure was executed end-to-end: a fresh `sonic-dash-ha` Ubuntu 22.04 container was created, dependencies and `libswsscommon` were installed/built, and `cargo build --workspace` completed successfully (all crates including `hamgrd`, `swbusd`, and `swss-common-bridge`). These are documentation-only files; no application code is affected.

#### Any platform specific information?
The container build targets `ubuntu:22.04` (amd64) for compatible `protoc`, boost, and libclang-14 versions. The deploy and testing skills target Linux SONiC SmartSwitch switches.

### Documentation
N/A — these files are themselves developer documentation. No wiki updates required.
