### PR TITLE
[ci] enable PR checker trigger for release branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,7 @@ pr:
   branches:
     include:
       - master
+      - 202???
   paths:
     exclude:
       - .github


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The Azure Pipelines PR checker for sonic-dash-ha only triggered on PRs targeting the master branch. PRs raised against release branches (e.g. 202605) did not run the PR validation pipeline, leaving release-branch changes unverified.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
The Azure Pipelines PR checker for sonic-dash-ha only triggered on PRs targeting the master branch. PRs raised against release branches (e.g. 202605) did not run the PR validation pipeline, leaving release-branch changes unverified.
#### How did you do it?
Added the 202??? branch pattern to the pr.branches.include list so the PR checker also triggers for release branches.
#### How did you verify/test it?

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
