### PR TITLE
[NPU-driven HA]Enable transition to Standalone and Standby in all states upon unplanned failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,5 @@ ci-lint:
 ci-test:
 	cargo test           --workspace --all-features
 	cargo clean
-	cargo test --release --workspace --all-features
+	cargo test --release --workspace --all-features --exclude hamgrd
+	cargo test --release -p hamgrd --all-features -- --test-threads=1

--- a/Makefile
+++ b/Makefile
@@ -79,5 +79,4 @@ ci-lint:
 ci-test:
 	cargo test           --workspace --all-features
 	cargo clean
-	cargo test --release --workspace --all-features --exclude hamgrd
-	cargo test --release -p hamgrd --all-features -- --test-threads=1
+	cargo test --release --workspace --all-features

--- a/crates/hamgrd/src/actors/ha_scope/npu.rs
+++ b/crates/hamgrd/src/actors/ha_scope/npu.rs
@@ -1557,6 +1557,7 @@ impl NpuHaScopeActor {
         current_state: &HaState,
         event: &HaEvent,
     ) -> Option<(HaState, &'static str)> {
+        // First, handle high-priority HA events that will force state transitions regardless of the current state
         if *event == HaEvent::Shutdown {
             return match current_state {
                 HaState::Dead => None,
@@ -1571,6 +1572,10 @@ impl NpuHaScopeActor {
                 }
                 _ => Some((HaState::Destroying, "planned shutdown")),
             };
+        } else if *event == HaEvent::EnterStandalone {
+            return Some((HaState::Standalone, "won the standalone selection"));
+        } else if *event == HaEvent::EnterStandby {
+            return Some((HaState::Standby, "peer became standalone, entering standby"));
         }
 
         match current_state {
@@ -1731,11 +1736,7 @@ impl NpuHaScopeActor {
                 }
             }
             HaState::SwitchingToStandalone => {
-                if *event == HaEvent::EnterStandalone {
-                    Some((HaState::Standalone, "won the standalone selection"))
-                } else if *event == HaEvent::EnterStandby {
-                    Some((HaState::Standby, "peer became standalone, entering standby"))
-                } else if *event == HaEvent::LeavingStandalone {
+                if *event == HaEvent::LeavingStandalone {
                     match target_state {
                         TargetState::Active => Some((HaState::Active, "failed to enter standalone")),
                         TargetState::Standby => Some((HaState::Standby, "failed to enter standalone")),

--- a/crates/hamgrd/src/actors/ha_scope/npu.rs
+++ b/crates/hamgrd/src/actors/ha_scope/npu.rs
@@ -1573,9 +1573,15 @@ impl NpuHaScopeActor {
                 _ => Some((HaState::Destroying, "planned shutdown")),
             };
         } else if *event == HaEvent::EnterStandalone {
-            return Some((HaState::Standalone, "won the standalone selection"));
+            return match current_state {
+                HaState::Unspecified | HaState::Dead | HaState::Destroying => None,
+                _ => Some((HaState::Standalone, "won the standalone selection")),
+            };
         } else if *event == HaEvent::EnterStandby {
-            return Some((HaState::Standby, "peer became standalone, entering standby"));
+            return match current_state {
+                HaState::Unspecified | HaState::Dead | HaState::Destroying => None,
+                _ => Some((HaState::Standby, "peer became standalone, entering standby")),
+            };
         }
 
         match current_state {


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Previously, we only allowed the state machine to react to "EnterStandalone" and "EnterStandby" when in SwitchingToStandalone state. This is not correct since unplanned failures can happen in any state. Now, we add this change to enable transition to Standalone and Standby in all states.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
