### PR TITLE
Use sonic-swss agent pool for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 1. Install Rust using [rustup](https://rustup.rs/).
 
-2. Install Protobuf compiler (`protoc`)
+2. Install Protobuf compiler (`protoc`).
 
     ```sh
     # Ubuntu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,7 @@ stages:
   jobs:
   - job:
     displayName: "amd64/ubuntu-22.04"
-    pool:
-      vmImage: 'ubuntu-22.04'
+    pool: sonicso1ES-amd64
     
     container:
       image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest


### PR DESCRIPTION
Summary:
- Switch the dash-ha Azure Pipelines build job from Microsoft-hosted `ubuntu-22.04` to the `sonicso1ES-amd64` agent pool used by sonic-swss.

Validation:
- Parsed `azure-pipelines.yml` successfully with PyYAML.