### PR TITLE
[202605] Cherry-pick #167 + #175 combined (fix CI failure of #191)

### DIFF
--- a/crates/hamgrd/src/actors/ha_scope/base.rs
+++ b/crates/hamgrd/src/actors/ha_scope/base.rs
@@ -400,6 +400,7 @@ impl HaScopeBase {
 
         let mut npu_ha_scope_state = self.get_npu_ha_scope_state(internal).unwrap_or_default();
 
+        npu_ha_scope_state.version = self.dash_ha_scope_config.as_ref().map(|c| c.version.clone());
         npu_ha_scope_state.creation_time_in_ms = 0; /*todo */
         npu_ha_scope_state.last_heartbeat_time_in_ms = 0; /* todo: wait until heartbeat is implemented */
         npu_ha_scope_state.vip_v4 = haset.ha_set.vip_v4.clone();

--- a/crates/hamgrd/src/actors/ha_scope/dpu.rs
+++ b/crates/hamgrd/src/actors/ha_scope/dpu.rs
@@ -286,9 +286,11 @@ impl DpuHaScopeActor {
             return Ok(());
         };
 
+        npu_ha_scope_state.version = Some(dash_ha_scope_config.version.clone());
+
         // in dpu driven mode, local_ha_state is same as dpu acked ha state
         npu_ha_scope_state.local_ha_state = Some(dpu_ha_scope_state.ha_state.clone());
-        npu_ha_scope_state.local_ha_state_last_updated_time_in_ms = Some(dpu_ha_scope_state.ha_role_start_time);
+        npu_ha_scope_state.local_ha_state_last_updated_time_in_ms = Some(dpu_ha_scope_state.ha_state_start_time);
         // The reason of the last HA state change.
         npu_ha_scope_state.local_ha_state_last_updated_reason = Some("dpu initiated".to_string());
 

--- a/crates/hamgrd/src/actors/ha_scope/mod.rs
+++ b/crates/hamgrd/src/actors/ha_scope/mod.rs
@@ -262,21 +262,24 @@ mod test {
             let (vdpu1_id, _vdpu1_state_obj) = make_vdpu_actor_state(true, &dpu1);
 
             // Initial state of NPU DASH_HA_SCOPE_STATE
-            let npu_ha_scope_state1 = make_npu_ha_scope_state(&vdpu0_state_obj, &ha_set_obj);
+            let mut npu_ha_scope_state1 = make_npu_ha_scope_state(&vdpu0_state_obj, &ha_set_obj);
+            npu_ha_scope_state1.version = Some("1".to_string());
             let npu_ha_scope_state_fvs1 = to_field_values(&npu_ha_scope_state1).unwrap();
 
             // NPU DASH_HA_SCOPE_STATE after DPU DASH_HA_SCOPE_STATE update
             let dpu_ha_state_state2 = make_dpu_ha_scope_state("dead");
             let mut npu_ha_scope_state2 = npu_ha_scope_state1.clone();
-            update_npu_ha_scope_state_by_dpu_scope_state(&mut npu_ha_scope_state2, &dpu_ha_state_state2, "active");
+            update_npu_ha_scope_state_by_dpu_scope_state(&mut npu_ha_scope_state2, &dpu_ha_state_state2, "active", "1");
             let npu_ha_scope_state_fvs2 = to_field_values(&npu_ha_scope_state2).unwrap();
-
+            let mut npu_ha_scope_state2_1 = npu_ha_scope_state2.clone();
+            npu_ha_scope_state2_1.version = Some("2".to_string());
+            let npu_ha_scope_state_fvs2_1 = to_field_values(&npu_ha_scope_state2_1).unwrap();
             // NPU DASH_HA_SCOPE_STATE after DPU DASH_HA_SCOPE_STATE role activation requestion
             let mut dpu_ha_state_state3 = dpu_ha_state_state2.clone();
             dpu_ha_state_state3.activate_role_pending = true;
             dpu_ha_state_state3.last_updated_time = now_in_millis();
             let mut npu_ha_scope_state3 = npu_ha_scope_state2.clone();
-            update_npu_ha_scope_state_by_dpu_scope_state(&mut npu_ha_scope_state3, &dpu_ha_state_state3, "active");
+            update_npu_ha_scope_state_by_dpu_scope_state(&mut npu_ha_scope_state3, &dpu_ha_state_state3, "active", "2");
             update_npu_ha_scope_state_pending_ops(
                 &mut npu_ha_scope_state3,
                 vec![("1".to_string(), "activate_role".to_string())],
@@ -338,7 +341,7 @@ mod test {
                         }},
 
                 // Write to NPU DASH_HA_SCOPE_STATE through internal state
-                chkdb! { type: NpuDashHaScopeState, key: &scope_id_in_state, data: npu_ha_scope_state_fvs2 },
+                chkdb! { type: NpuDashHaScopeState, key: &scope_id_in_state, data: npu_ha_scope_state_fvs2},
 
                 // Send DASH_HA_SCOPE_CONFIG_TABLE to actor with admin state enabled
                 send! { key: HaScopeConfig::table_name(), data: { "key": &scope_id, "operation": "Set",
@@ -366,7 +369,7 @@ mod test {
                         addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())  },
 
                 // Write to NPU DASH_HA_SCOPE_STATE through internal state
-                chkdb! { type: NpuDashHaScopeState, key: &scope_id_in_state, data: npu_ha_scope_state_fvs2 },
+                chkdb! { type: NpuDashHaScopeState, key: &scope_id_in_state, data: npu_ha_scope_state_fvs2_1 },
 
                 // Send DPU DASH_HA_SCOPE_STATE with role activation request to the actor
                 send! { key: DpuDashHaScopeState::table_name(), data: {"key": DpuDashHaScopeState::table_name(), "operation": "Set",
@@ -394,13 +397,14 @@ mod test {
 
             // continue the test to activate the role
             let mut npu_ha_scope_state4 = npu_ha_scope_state3.clone();
+            npu_ha_scope_state4.version = Some("3".to_string());
             update_npu_ha_scope_state_pending_ops(&mut npu_ha_scope_state4, vec![]);
             let npu_ha_scope_state_fvs4 = to_field_values(&npu_ha_scope_state4).unwrap();
 
             let mut dpu_ha_state_state5 = make_dpu_ha_scope_state("active");
             dpu_ha_state_state5.ha_term = Some("2".to_string());
             let mut npu_ha_scope_state5: NpuDashHaScopeState = npu_ha_scope_state4.clone();
-            update_npu_ha_scope_state_by_dpu_scope_state(&mut npu_ha_scope_state5, &dpu_ha_state_state5, "active");
+            update_npu_ha_scope_state_by_dpu_scope_state(&mut npu_ha_scope_state5, &dpu_ha_state_state5, "active", "3");
             let npu_ha_scope_state_fvs5 = to_field_values(&npu_ha_scope_state5).unwrap();
 
             let bfd_state = make_dpu_bfd_state(vec!["10.0.0.0", "10.0.1.0"], Vec::new());
@@ -484,6 +488,7 @@ mod test {
 
             // execute planned shutdown
             let mut npu_ha_scope_state7 = npu_ha_scope_state6.clone();
+            npu_ha_scope_state7.version = Some("4".to_string());
             npu_ha_scope_state7.local_target_asic_ha_state = Some("dead".to_string());
             let npu_ha_scope_state_fvs7 = to_field_values(&npu_ha_scope_state7).unwrap();
             #[rustfmt::skip]
@@ -711,6 +716,7 @@ mod test {
             npu_ha_scope_state_pending_active_activation.local_target_asic_ha_state = Some("active".to_string());
             npu_ha_scope_state_pending_active_activation.pending_operation_types =
                 Some(vec!["activate_role".to_string()]);
+            npu_ha_scope_state_pending_active_activation.version = Some("1".to_string());
             let npu_ha_scope_state_pending_active_activation_fvs =
                 to_field_values(&npu_ha_scope_state_pending_active_activation).unwrap();
 
@@ -758,7 +764,7 @@ mod test {
                 // Expect HaScopeActorState: initializing_to_active -> pending_active_activation
                 recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::PendingActiveActivation.as_str_name(), "term": "0", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
                 recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::PendingActiveActivation.as_str_name(), "term": "0", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
-                
+
 
                 // Expect a pending role activation request in NPU DASH_HA_SCOPE_STATE table
                 chkdb! { type: NpuDashHaScopeState,
@@ -787,7 +793,7 @@ mod test {
                         "field_values": {"json": format!(r#"{{"version":"2","disabled":false,"desired_ha_state":{},"owner":{},"ha_set_id":"{ha_set_id}","approved_pending_operation_ids":["{op_id}"]}}"#, DesiredHaState::Active as i32, HaOwner::Switch as i32)},
                         },
                         addr: crate::common_bridge_sp::<HaScopeConfig>(&runtime.get_swbus_edge()) },
-                
+
                 // Expect a bulkSyncCompleted message
                 recv! { key: BulkSyncUpdate::msg_key(&scope_id), data: { "dst_actor_id": &peer_scope_id, "finished": true }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id) },
 
@@ -902,6 +908,7 @@ mod test {
             npu_ha_scope_state_pending_standby_activation.local_target_asic_ha_state = Some("standby".to_string());
             npu_ha_scope_state_pending_standby_activation.pending_operation_types =
                 Some(vec!["activate_role".to_string()]);
+            npu_ha_scope_state_pending_standby_activation.version = Some("1".to_string());
             let npu_ha_scope_state_pending_standby_activation_fvs =
                 to_field_values(&npu_ha_scope_state_pending_standby_activation).unwrap();
 
@@ -958,7 +965,7 @@ mod test {
                 // Expect a HaScopeActorState: connected -> initializing_to_standby
                 recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "0", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
                 recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "0", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
-                
+
                 // Mock a bulkSyncCompleted message from the peer
                 send! { key: BulkSyncUpdate::msg_key(&peer_scope_id), data: { "dst_actor_id": &scope_id, "finished": true }},
                 // Expect a HaScopeActorState: initializing_to_standby -> pending_standby_activation

--- a/crates/hamgrd/src/actors/ha_scope/mod.rs
+++ b/crates/hamgrd/src/actors/ha_scope/mod.rs
@@ -564,7 +564,7 @@ mod test {
             dpu_ha_scope_state.last_updated_time = now_in_millis();
 
             let mut npu_ha_scope_state = make_npu_ha_scope_state(&vdpu0_state_obj, &ha_set_obj);
-            update_npu_ha_scope_state_by_dpu_scope_state(&mut npu_ha_scope_state, &dpu_ha_scope_state, "active");
+            update_npu_ha_scope_state_by_dpu_scope_state(&mut npu_ha_scope_state, &dpu_ha_scope_state, "active", "1");
             update_npu_ha_scope_state_pending_ops(
                 &mut npu_ha_scope_state,
                 vec![("1".to_string(), "brainsplit_recover".to_string())],
@@ -630,6 +630,7 @@ mod test {
                 .unwrap();
 
             let mut expected_npu_ha_scope_state = npu_ha_scope_state.clone();
+            expected_npu_ha_scope_state.version = Some("2".to_string());
             update_npu_ha_scope_state_pending_ops(&mut expected_npu_ha_scope_state, vec![]);
             let expected_npu_ha_scope_state_fvs = to_field_values(&expected_npu_ha_scope_state).unwrap();
 

--- a/crates/hamgrd/src/actors/ha_set.rs
+++ b/crates/hamgrd/src/actors/ha_set.rs
@@ -33,6 +33,7 @@ pub struct HaSetActor {
     ha_owner: HaOwner,
     bridges: Vec<ConsumerBridge>,
     bfd_session_npu_ips: HashSet<String>,
+    ha_scope_states: HashMap<String, CachedHaScopeState>,
 }
 
 impl DbBasedActor for HaSetActor {
@@ -44,6 +45,7 @@ impl DbBasedActor for HaSetActor {
             ha_owner: HaOwner::Unspecified,
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states: HashMap::new(),
         };
         Ok(actor)
     }
@@ -58,8 +60,15 @@ impl DbBasedActor for HaSetActor {
 }
 
 struct VDpuStateExt {
+    id: String,
     vdpu: VDpuActorState,
     is_primary: bool,
+}
+
+struct CachedHaScopeState {
+    new_state: String,
+    vdpu_id: String,
+    peer_vdpu_id: String,
 }
 
 impl HaSetActor {
@@ -281,10 +290,23 @@ impl HaSetActor {
             return Ok(());
         }
 
-        let pinned_state = self
-            .dash_ha_set_config
-            .as_ref()
-            .map(|cfg| cfg.pinned_vdpu_bfd_probe_states.clone());
+        let pinned_state = self.dash_ha_set_config.as_ref().map(|cfg| {
+            let pinned = &cfg.pinned_vdpu_bfd_probe_states;
+            if vdpus.len() < cfg.vdpu_ids.len() && !pinned.is_empty() {
+                // Only preserve pinned states corresponding to VDPUs in the endpoint list
+                vdpus
+                    .iter()
+                    .filter_map(|vdpu_ext| {
+                        cfg.vdpu_ids
+                            .iter()
+                            .position(|vid| vid == &vdpu_ext.id)
+                            .and_then(|idx| pinned.get(idx).cloned())
+                    })
+                    .collect()
+            } else {
+                pinned.clone()
+            }
+        });
 
         // update vnet route tunnel table
         let vnet_route = VnetRouteTunnelTable {
@@ -400,10 +422,11 @@ impl HaSetActor {
                 .map(str::trim)
                 .filter(|id| !id.is_empty())
             {
-                result.push(
-                    self.get_vdpu(incoming, id)
-                        .map(|vdpu| VDpuStateExt { vdpu, is_primary: true }),
-                );
+                result.push(self.get_vdpu(incoming, id).map(|vdpu| VDpuStateExt {
+                    id: id.to_string(),
+                    vdpu,
+                    is_primary: true,
+                }));
                 seen.insert(id.to_string());
             }
         }
@@ -415,6 +438,7 @@ impl HaSetActor {
             .filter(|id| !id.is_empty() && !seen.contains(*id))
         {
             result.push(self.get_vdpu(incoming, id).map(|vdpu| VDpuStateExt {
+                id: id.clone(),
                 vdpu,
                 is_primary: false,
             }));
@@ -446,6 +470,177 @@ impl HaSetActor {
                 error!("Failed to deserialize HaScopeActorState from the message: {}", e);
                 None
             }
+        }
+    }
+
+    fn prune_cached_ha_scope_states(&mut self) {
+        let Some(ref dash_ha_set_config) = self.dash_ha_set_config else {
+            self.ha_scope_states.clear();
+            return;
+        };
+
+        let vdpu_ids: HashSet<String> = dash_ha_set_config
+            .vdpu_ids
+            .iter()
+            .map(|id| id.trim().to_string())
+            .filter(|id| !id.is_empty())
+            .collect();
+        self.ha_scope_states
+            .retain(|_, state| vdpu_ids.contains(&state.vdpu_id));
+    }
+
+    fn cache_ha_scope_actor_state(&mut self, source_key: &str, ha_scope: &HaScopeActorState) {
+        if ha_scope.vdpu_id.trim().is_empty() {
+            debug!("Ignoring HA scope state update with empty vdpu_id");
+            return;
+        }
+
+        // Keyed by the source HA scope's message key so subsequent updates from the
+        // same HA scope overwrite the prior entry in place.
+        self.ha_scope_states.insert(
+            source_key.to_string(),
+            CachedHaScopeState {
+                new_state: ha_scope.new_state.clone(),
+                vdpu_id: ha_scope.vdpu_id.clone(),
+                peer_vdpu_id: ha_scope.peer_vdpu_id.clone(),
+            },
+        );
+    }
+
+    fn configured_vdpu_ids(&self) -> Vec<String> {
+        self.dash_ha_set_config
+            .as_ref()
+            .map(|cfg| {
+                cfg.vdpu_ids
+                    .iter()
+                    .map(|id| id.trim().to_string())
+                    .filter(|id| !id.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn preferred_vdpu_ids(&self) -> Vec<String> {
+        self.dash_ha_set_config
+            .as_ref()
+            .map(|cfg| {
+                cfg.preferred_vdpu_id
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map(ToOwned::to_owned)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Append non-primary endpoints after `primary_id`, putting the Active scope's reported
+    /// `peer_vdpu_id` first so the standby endpoint is deterministic rather than config-order.
+    fn add_backup_vdpu_ids(
+        result: &mut Vec<(String, bool)>,
+        primary_id: &str,
+        configured_vdpu_ids: &[String],
+        peer_vdpu_id: &str,
+    ) {
+        if !peer_vdpu_id.trim().is_empty() && configured_vdpu_ids.iter().any(|id| id == peer_vdpu_id) {
+            result.push((peer_vdpu_id.to_string(), false));
+        }
+
+        for vdpu_id in configured_vdpu_ids {
+            if vdpu_id != primary_id && !result.iter().any(|(id, _)| id == vdpu_id) {
+                result.push((vdpu_id.clone(), false));
+            }
+        }
+    }
+
+    fn select_vdpu_ids_from_ha_scope_states(&self) -> Option<Vec<(String, bool)>> {
+        let configured_vdpu_ids = self.configured_vdpu_ids();
+        if configured_vdpu_ids.len() < 2 {
+            return None;
+        }
+
+        let ha_scope_states: Option<Vec<&CachedHaScopeState>> = configured_vdpu_ids
+            .iter()
+            .map(|vdpu_id| self.ha_scope_states.values().find(|state| &state.vdpu_id == vdpu_id))
+            .collect();
+        let Some(ha_scope_states) = ha_scope_states else {
+            info!("Not all HA scope state is ready yet");
+            return None;
+        };
+
+        let active_states: Vec<&CachedHaScopeState> = ha_scope_states
+            .iter()
+            .copied()
+            .filter(|state| state.new_state == HaState::Active.as_str_name())
+            .collect();
+        if active_states.len() == 1 {
+            let primary_id = active_states[0].vdpu_id.clone();
+            let mut selected = vec![(primary_id.clone(), true)];
+            Self::add_backup_vdpu_ids(
+                &mut selected,
+                &primary_id,
+                &configured_vdpu_ids,
+                &active_states[0].peer_vdpu_id,
+            );
+            return Some(selected);
+        }
+
+        let standalone_states: Vec<&CachedHaScopeState> = ha_scope_states
+            .iter()
+            .copied()
+            .filter(|state| state.new_state == HaState::Standalone.as_str_name())
+            .collect();
+        if standalone_states.len() == 1 {
+            let primary_id = standalone_states[0].vdpu_id.clone();
+            let mut selected = vec![(primary_id.clone(), true)];
+            // Include the other configured vDPU as a backup endpoint so the route write
+            // always contains the local vDPU (otherwise the any_managed gate in
+            // update_vnet_route_tunnel_table skips the write on the non-winner side).
+            Self::add_backup_vdpu_ids(&mut selected, &primary_id, &configured_vdpu_ids, "");
+            return Some(selected);
+        }
+
+        if standalone_states.len() == configured_vdpu_ids.len() {
+            let standalone_vdpu_ids: HashSet<&str> =
+                standalone_states.iter().map(|state| state.vdpu_id.as_str()).collect();
+            let primary_id = self
+                .preferred_vdpu_ids()
+                .into_iter()
+                .find(|vdpu_id| standalone_vdpu_ids.contains(vdpu_id.as_str()))
+                .or_else(|| standalone_states.first().map(|state| state.vdpu_id.clone()))?;
+            let mut selected = vec![(primary_id.clone(), true)];
+            // All configured vDPUs are Standalone here, and Standalone scopes have no peer,
+            // so this fills in the remaining vDPUs as backups in config order.
+            Self::add_backup_vdpu_ids(&mut selected, &primary_id, &configured_vdpu_ids, "");
+            return Some(selected);
+        }
+
+        None
+    }
+
+    fn get_vdpus_from_ha_scope_states(&self, incoming: &Incoming) -> Option<Vec<VDpuStateExt>> {
+        let selected_vdpu_ids = self.select_vdpu_ids_from_ha_scope_states()?;
+        let mut vdpus = Vec::new();
+
+        for (vdpu_id, is_primary) in selected_vdpu_ids {
+            match self.get_vdpu(incoming, &vdpu_id) {
+                Some(vdpu) => vdpus.push(VDpuStateExt {
+                    id: vdpu_id,
+                    vdpu,
+                    is_primary,
+                }),
+                None if is_primary => {
+                    info!("Primary DPU info is not ready yet");
+                    return None;
+                }
+                None => info!("Backup DPU info is not ready yet"),
+            }
+        }
+
+        if vdpus.is_empty() {
+            None
+        } else {
+            Some(vdpus)
         }
     }
 
@@ -576,6 +771,7 @@ impl HaSetActor {
             .unwrap_or_default();
 
         self.dash_ha_set_config = Some(decode_from_field_values(&dpu_kfv.field_values).unwrap());
+        self.prune_cached_ha_scope_states();
 
         // Subscribe to the DPU Actor for state updates.
         self.register_to_vdpu_actor(outgoing, true)?;
@@ -732,6 +928,7 @@ impl HaSetActor {
             return Ok(());
         };
 
+        self.cache_ha_scope_actor_state(key, &ha_scope);
         self.ha_owner = HaOwner::try_from(ha_scope.owner).unwrap_or(HaOwner::Unspecified);
 
         // When HA scope is launching (dead -> connecting), reset dp_channel_is_alive to true
@@ -754,39 +951,12 @@ impl HaSetActor {
                 );
             }
 
-            let mut vdpus = Vec::new();
-            if ha_scope.new_state == HaState::Active.as_str_name() {
-                // primary (Active) DPU
-                vdpus.push(
-                    self.get_vdpu(incoming, &ha_scope.vdpu_id)
-                        .map(|vdpu| VDpuStateExt { vdpu, is_primary: true }),
-                );
-                // secondary (Standby) DPU
-                vdpus.push(
-                    self.get_vdpu(incoming, &ha_scope.peer_vdpu_id)
-                        .map(|vdpu| VDpuStateExt {
-                            vdpu,
-                            is_primary: false,
-                        }),
-                );
-            } else if ha_scope.new_state == HaState::Standalone.as_str_name() {
-                // primary (Standalone) DPU
-                vdpus.push(
-                    self.get_vdpu(incoming, &ha_scope.vdpu_id)
-                        .map(|vdpu| VDpuStateExt { vdpu, is_primary: true }),
-                );
-            }
-
-            if !vdpus.is_empty() {
+            if let Some(vdpus) = self.get_vdpus_from_ha_scope_states(incoming) {
                 info!(
                     "Received HaScopeStateUpdate with owner={} state={}, updating VNET ROUTE table.",
                     self.ha_owner as i32, &ha_scope.new_state
                 );
-                // update VNET ROUTE Table
-                let vdpus: Vec<VDpuStateExt> = vdpus.into_iter().flatten().collect();
-                if !vdpus.is_empty() {
-                    self.update_vnet_route_tunnel_table(&vdpus, incoming, outgoing).await?;
-                }
+                self.update_vnet_route_tunnel_table(&vdpus, incoming, outgoing).await?;
             }
         }
 
@@ -854,6 +1024,7 @@ impl Actor for HaSetActor {
 
 #[cfg(test)]
 mod test {
+    use super::CachedHaScopeState;
     use crate::actors::KeyOperation;
     use crate::{
         actors::{
@@ -885,6 +1056,47 @@ mod test {
         kfv.field_values.clear();
         kfv.field_values.insert("json".to_string(), json.into());
         kfv.field_values.clone()
+    }
+
+    #[test]
+    fn ha_scope_route_selection_prefers_configured_vdpu_when_both_standalone() {
+        let (ha_set_id, mut ha_set_cfg) = make_dpu_scope_ha_set_config(0, 0);
+        let vdpu0_id = ha_set_cfg.vdpu_ids[0].clone();
+        let vdpu1_id = ha_set_cfg.vdpu_ids[1].clone();
+        ha_set_cfg.preferred_vdpu_id = vdpu1_id.clone();
+
+        let mut ha_scope_states = HashMap::new();
+        ha_scope_states.insert(
+            format!("HaScopeStateUpdate|{vdpu0_id}:dummy"),
+            CachedHaScopeState {
+                new_state: HaState::Standalone.as_str_name().to_string(),
+                vdpu_id: vdpu0_id.clone(),
+                peer_vdpu_id: String::new(),
+            },
+        );
+        ha_scope_states.insert(
+            format!("HaScopeStateUpdate|{vdpu1_id}:dummy"),
+            CachedHaScopeState {
+                new_state: HaState::Standalone.as_str_name().to_string(),
+                vdpu_id: vdpu1_id.clone(),
+                peer_vdpu_id: String::new(),
+            },
+        );
+
+        let ha_set_actor = HaSetActor {
+            id: ha_set_id,
+            dash_ha_set_config: Some(ha_set_cfg),
+            dp_channel_is_alive: false,
+            ha_owner: HaOwner::Switch,
+            bridges: Vec::new(),
+            bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states,
+        };
+
+        assert_eq!(
+            ha_set_actor.select_vdpu_ids_from_ha_scope_states(),
+            Some(vec![(vdpu1_id, true), (vdpu0_id, false)])
+        );
     }
 
     #[tokio::test]
@@ -970,6 +1182,7 @@ mod test {
             ha_owner: HaOwner::Dpu,
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states: HashMap::new(),
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1177,6 +1390,7 @@ mod test {
             ha_owner: HaOwner::Dpu,
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states: HashMap::new(),
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1318,10 +1532,19 @@ mod test {
         };
         let expected_vnet_route_active = swss_serde::to_field_values(&expected_vnet_route_active).unwrap();
 
-        // Expected VnetRoute when ha_scope state is Standalone (only primary)
-        let expected_vnet_route_standalone = VnetRouteTunnelTable {
-            endpoint: vec![vdpu0_state_obj.dpu.pa_ipv4.clone()],
-            endpoint_monitor: Some(vec![vdpu0_state_obj.dpu.pa_ipv4.clone()]),
+        // Expected VnetRoute when only the local ha_scope is Standalone. The selector
+        // still includes the peer vDPU as a backup so the route keeps two endpoints
+        // and the route write isn't skipped on the side whose Standalone winner is
+        // a remote vDPU.
+        let expected_vnet_route_one_standalone = VnetRouteTunnelTable {
+            endpoint: vec![
+                vdpu0_state_obj.dpu.pa_ipv4.clone(),
+                vdpu1_state_obj.dpu.npu_ipv4.clone(),
+            ],
+            endpoint_monitor: Some(vec![
+                vdpu0_state_obj.dpu.pa_ipv4.clone(),
+                vdpu1_state_obj.dpu.pa_ipv4.clone(),
+            ]),
             monitoring: Some("custom_bfd".into()),
             primary: Some(vec![vdpu0_state_obj.dpu.pa_ipv4.clone()]),
             rx_monitor_timer: global_cfg.dpu_bfd_probe_interval_in_ms,
@@ -1329,9 +1552,30 @@ mod test {
             check_directly_connected: Some(true),
             pinned_state: Some(ha_set_cfg.pinned_vdpu_bfd_probe_states.clone()),
         };
-        let expected_vnet_route_standalone = swss_serde::to_field_values(&expected_vnet_route_standalone).unwrap();
+        let expected_vnet_route_one_standalone =
+            swss_serde::to_field_values(&expected_vnet_route_one_standalone).unwrap();
+
+        let expected_vnet_route_both_standalone = VnetRouteTunnelTable {
+            endpoint: vec![
+                vdpu0_state_obj.dpu.pa_ipv4.clone(),
+                vdpu1_state_obj.dpu.npu_ipv4.clone(),
+            ],
+            endpoint_monitor: Some(vec![
+                vdpu0_state_obj.dpu.pa_ipv4.clone(),
+                vdpu1_state_obj.dpu.pa_ipv4.clone(),
+            ]),
+            monitoring: Some("custom_bfd".into()),
+            primary: Some(vec![vdpu0_state_obj.dpu.pa_ipv4.clone()]),
+            rx_monitor_timer: global_cfg.dpu_bfd_probe_interval_in_ms,
+            tx_monitor_timer: global_cfg.dpu_bfd_probe_interval_in_ms,
+            check_directly_connected: Some(true),
+            pinned_state: Some(ha_set_cfg.pinned_vdpu_bfd_probe_states.clone()),
+        };
+        let expected_vnet_route_both_standalone =
+            swss_serde::to_field_values(&expected_vnet_route_both_standalone).unwrap();
 
         let scope_id = format!("{}:{}", vdpu0_id, ha_set_id);
+        let peer_scope_id = format!("{}:{}", vdpu1_id, ha_set_id);
 
         let ha_set_actor = HaSetActor {
             id: ha_set_id.clone(),
@@ -1340,6 +1584,7 @@ mod test {
             ha_owner: HaOwner::Switch,
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states: HashMap::new(),
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1355,6 +1600,12 @@ mod test {
                     addr: runtime.sp(VDpuActor::name(), &vdpu0_id) },
             recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &ha_set_id), data: { "active": true },
                     addr: runtime.sp(VDpuActor::name(), &vdpu1_id) },
+                send! { key: HaScopeActorState::msg_key(&scope_id),
+                    data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connected.as_str_name(), "timestamp": 12343i64, "term": "0", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id },
+                    addr: runtime.sp("ha-scope", &scope_id) },
+                send! { key: HaScopeActorState::msg_key(&peer_scope_id),
+                    data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Standby.as_str_name(), "timestamp": 12344i64, "term": "0", "vdpu_id": &vdpu1_id, "peer_vdpu_id": &vdpu0_id },
+                    addr: runtime.sp("ha-scope", &peer_scope_id) },
             // Send registration request from ha-scope actor
             send! { key: ActorRegistration::msg_key(RegistrationType::HaSetState, &scope_id), data: { "active": true},
                     addr: runtime.sp("ha-scope", &scope_id) },
@@ -1391,14 +1642,14 @@ mod test {
             recv! { key: HaSetActorState::msg_key(&ha_set_id), data: { "up": false, "ha_set": &ha_set_obj, "vdpu_ids": vec![vdpu0_id.clone(), vdpu1_id.clone()], "pinned_vdpu_bfd_probe_states": ha_set_cfg.pinned_vdpu_bfd_probe_states.clone() },
                     addr: runtime.sp("ha-scope", &scope_id) },
 
-            // === Phase 3: ha_scope Standalone — triggers VnetRoute with only primary ===
+            // === Phase 3: one ha_scope Standalone — peer kept as backup endpoint ===
 
             send! { key: HaScopeActorState::msg_key(&scope_id),
                     data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Standalone.as_str_name(), "timestamp": 12346i64, "term": "2", "vdpu_id": &vdpu0_id, "peer_vdpu_id": "" },
                     addr: runtime.sp("ha-scope", &scope_id) },
-            // Verify VnetRouteTunnelTable with only primary DPU
+            // Verify VnetRouteTunnelTable still has both endpoints, primary = the Standalone winner
             recv! { key: &ha_set_id, data: {"key": format!("{}:{}", global_cfg.dpu_vnet.as_ref().unwrap(), ip_to_string(ha_set_cfg.vip_v4.as_ref().unwrap())),
-                      "operation": "Set", "field_values": expected_vnet_route_standalone},
+                      "operation": "Set", "field_values": expected_vnet_route_one_standalone},
                     addr: crate::common_bridge_sp::<VnetRouteTunnelTable>(&runtime.get_swbus_edge()) },
             // Verify DashHaSetTable updated after ha_scope state update
             recv! { key: &ha_set_id, data: {"key": &ha_set_id,  "operation": "Set", "field_values": ha_set_obj_fvs},
@@ -1406,7 +1657,20 @@ mod test {
             recv! { key: HaSetActorState::msg_key(&ha_set_id), data: { "up": false, "ha_set": &ha_set_obj, "vdpu_ids": vec![vdpu0_id.clone(), vdpu1_id.clone()], "pinned_vdpu_bfd_probe_states": ha_set_cfg.pinned_vdpu_bfd_probe_states.clone() },
                     addr: runtime.sp("ha-scope", &scope_id) },
 
-            // === Phase 4: Cleanup ===
+                // === Phase 4: both ha_scopes Standalone — preferred vDPU remains primary ===
+
+                send! { key: HaScopeActorState::msg_key(&peer_scope_id),
+                    data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Standalone.as_str_name(), "timestamp": 12347i64, "term": "2", "vdpu_id": &vdpu1_id, "peer_vdpu_id": "" },
+                    addr: runtime.sp("ha-scope", &peer_scope_id) },
+                recv! { key: &ha_set_id, data: {"key": format!("{}:{}", global_cfg.dpu_vnet.as_ref().unwrap(), ip_to_string(ha_set_cfg.vip_v4.as_ref().unwrap())),
+                      "operation": "Set", "field_values": expected_vnet_route_both_standalone},
+                    addr: crate::common_bridge_sp::<VnetRouteTunnelTable>(&runtime.get_swbus_edge()) },
+                recv! { key: &ha_set_id, data: {"key": &ha_set_id,  "operation": "Set", "field_values": ha_set_obj_fvs},
+                    addr: crate::common_bridge_sp::<DashHaSetTable>(&runtime.get_swbus_edge()) },
+                recv! { key: HaSetActorState::msg_key(&ha_set_id), data: { "up": false, "ha_set": &ha_set_obj, "vdpu_ids": vec![vdpu0_id.clone(), vdpu1_id.clone()], "pinned_vdpu_bfd_probe_states": ha_set_cfg.pinned_vdpu_bfd_probe_states.clone() },
+                    addr: runtime.sp("ha-scope", &scope_id) },
+
+                // === Phase 5: Cleanup ===
 
             send! { key: HaSetActor::table_name(), data: { "key": HaSetActor::table_name(), "operation": "Del", "field_values": ha_set_cfg_fvs },
                     addr: crate::common_bridge_sp::<HaSetConfig>(&runtime.get_swbus_edge()) },
@@ -1479,6 +1743,7 @@ mod test {
             ha_owner: HaOwner::Switch,
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states: HashMap::new(),
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1579,6 +1844,7 @@ mod test {
             dp_channel_is_alive: false,
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states: HashMap::new(),
             ha_owner: HaOwner::Dpu,
         };
 
@@ -1688,6 +1954,7 @@ mod test {
             ha_owner: HaOwner::Switch,
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states: HashMap::new(),
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1813,6 +2080,7 @@ mod test {
             ha_owner: HaOwner::Switch,
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states: HashMap::new(),
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1857,6 +2125,132 @@ mod test {
                     addr: crate::common_bridge_sp::<BfdSessionTable>(&runtime.get_swbus_edge()) },
             recv! { key: &ha_set_id, data: {"key": "default:default:10.0.1.0", "operation": "Set", "field_values": bfd_fvs},
                     addr: crate::common_bridge_sp::<BfdSessionTable>(&runtime.get_swbus_edge()) },
+
+            // === Phase 4: Cleanup ===
+            send! { key: HaSetActor::table_name(), data: { "key": HaSetActor::table_name(), "operation": "Del", "field_values": ha_set_cfg_fvs },
+                    addr: crate::common_bridge_sp::<HaSetConfig>(&runtime.get_swbus_edge()) },
+            recv! { key: &ha_set_id, data: {"key": &ha_set_id, "operation": "Del", "field_values": {}},
+                    addr: crate::common_bridge_sp::<DashHaSetTable>(&runtime.get_swbus_edge()) },
+            recv! { key: &ha_set_id, data: {"key": format!("{}:{}", global_cfg.dpu_vnet.as_ref().unwrap(), ip_to_string(ha_set_cfg.vip_v4.as_ref().unwrap())),
+                       "operation": "Del", "field_values": {}},
+                    addr: crate::common_bridge_sp::<VnetRouteTunnelTable>(&runtime.get_swbus_edge()) },
+            recv! { key: &ha_set_id, data: {"key": "default:default:10.0.0.0", "operation": "Del", "field_values": {}},
+                    addr: crate::common_bridge_sp::<BfdSessionTable>(&runtime.get_swbus_edge()) },
+            recv! { key: &ha_set_id, data: {"key": "default:default:10.0.1.0", "operation": "Del", "field_values": {}},
+                    addr: crate::common_bridge_sp::<BfdSessionTable>(&runtime.get_swbus_edge()) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &ha_set_id), data: { "active": false },
+                    addr: runtime.sp(VDpuActor::name(), &vdpu0_id) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &ha_set_id), data: { "active": false },
+                    addr: runtime.sp(VDpuActor::name(), &vdpu1_id) },
+        ];
+
+        test::run_commands(&runtime, runtime.sp(HaSetActor::name(), &ha_set_id), &commands).await;
+        if tokio::time::timeout(Duration::from_secs(3), handle).await.is_err() {
+            panic!("timeout waiting for actor to terminate");
+        }
+    }
+
+    // Test that receiving a Connecting HaScopeActorState resets dp_channel_is_alive to true.
+    // Flow: dp_channel starts true → DPU state "down" sets it false → Connecting state resets it to true.
+    #[tokio::test]
+    async fn ha_set_actor_connecting_resets_dp_channel() {
+        sonic_common::log::init_logger_for_test();
+
+        let _redis = Redis::start_config_db();
+        let runtime = test::create_actor_runtime(0, "10.0.0.0", "10::").await;
+
+        // prepare test data
+        let global_cfg = make_dash_ha_global_config();
+        let global_cfg_fvs = serde_json::to_value(swss_serde::to_field_values(&global_cfg).unwrap()).unwrap();
+
+        let (ha_set_id, ha_set_cfg) = make_dpu_scope_ha_set_config(0, 0);
+        let ha_set_cfg_fvs = protobuf_struct_to_kfv(&ha_set_cfg);
+
+        let dpu0 = make_local_dpu_actor_state(0, 0, true, None, None);
+        let dpu1 = make_remote_dpu_actor_state(1, 0);
+        let (vdpu0_id, vdpu0_state_obj) = make_vdpu_actor_state(true, &dpu0);
+        let (vdpu1_id, _vdpu1_state_obj) = make_vdpu_actor_state(true, &dpu1);
+        let vdpu0_state = serde_json::to_value(&vdpu0_state_obj).unwrap();
+        let vdpu1_state = serde_json::to_value(&_vdpu1_state_obj).unwrap();
+
+        let (_, mut ha_set_obj) = make_dpu_scope_ha_set_obj(0, 0);
+        ha_set_obj.owner = Some("switch".to_string());
+        let ha_set_obj_fvs = serde_json::to_value(swss_serde::to_field_values(&ha_set_obj).unwrap()).unwrap();
+
+        let bfd = BfdSessionTable {
+            tx_interval: global_cfg.dpu_bfd_probe_interval_in_ms,
+            rx_interval: global_cfg.dpu_bfd_probe_interval_in_ms,
+            multiplier: global_cfg.dpu_bfd_probe_multiplier,
+            multihop: true,
+            local_addr: vdpu0_state_obj.dpu.pa_ipv4.clone(),
+            session_type: Some("passive".to_string()),
+            shutdown: false,
+        };
+        let bfd_fvs = serde_json::to_value(swss_serde::to_field_values(&bfd).unwrap()).unwrap();
+
+        let scope_id = format!("{}:{}", vdpu0_id, ha_set_id);
+
+        // DPU HA Set State: dp_channel down
+        let dpu_ha_set_state_down = DpuDashHaSetState {
+            last_updated_time: 1000,
+            dp_channel_is_alive: "down".to_string(),
+        };
+        let dpu_ha_set_state_down_fvs =
+            serde_json::to_value(swss_serde::to_field_values(&dpu_ha_set_state_down).unwrap()).unwrap();
+
+        // Start with dp_channel_is_alive = true
+        let ha_set_actor = HaSetActor {
+            id: ha_set_id.clone(),
+            dash_ha_set_config: None,
+            dp_channel_is_alive: true,
+            ha_owner: HaOwner::Switch,
+            bridges: Vec::new(),
+            bfd_session_npu_ips: HashSet::new(),
+            ha_scope_states: HashMap::new(),
+        };
+
+        let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
+
+        #[rustfmt::skip]
+        let commands = [
+            // === Phase 1: Initial setup ===
+            send! { key: HaSetActor::table_name(), data: { "key": HaSetActor::table_name(), "operation": "Set", "field_values": ha_set_cfg_fvs },
+                    addr: crate::common_bridge_sp::<HaSetConfig>(&runtime.get_swbus_edge()) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &ha_set_id), data: { "active": true },
+                    addr: runtime.sp(VDpuActor::name(), &vdpu0_id) },
+            recv! { key: ActorRegistration::msg_key(RegistrationType::VDPUState, &ha_set_id), data: { "active": true },
+                    addr: runtime.sp(VDpuActor::name(), &vdpu1_id) },
+            send! { key: ActorRegistration::msg_key(RegistrationType::HaSetState, &scope_id), data: { "active": true},
+                    addr: runtime.sp("ha-scope", &scope_id) },
+            send! { key: "DASH_HA_GLOBAL_CONFIG", data: { "key": "DASH_HA_GLOBAL_CONFIG", "operation": "Set", "field_values": global_cfg_fvs } },
+            send! { key: VDpuActorState::msg_key(&vdpu0_id), data: vdpu0_state, addr: runtime.sp("vdpu", &vdpu0_id) },
+            send! { key: VDpuActorState::msg_key(&vdpu1_id), data: vdpu1_state, addr: runtime.sp("vdpu", &vdpu1_id) },
+            // Verify initial state (dp_channel up = true)
+            recv! { key: &ha_set_id, data: {"key": &ha_set_id, "operation": "Set", "field_values": ha_set_obj_fvs},
+                    addr: crate::common_bridge_sp::<DashHaSetTable>(&runtime.get_swbus_edge()) },
+            recv! { key: HaSetActorState::msg_key(&ha_set_id), data: { "up": true, "ha_set": &ha_set_obj, "vdpu_ids": vec![vdpu0_id.clone(), vdpu1_id.clone()], "pinned_vdpu_bfd_probe_states": ha_set_cfg.pinned_vdpu_bfd_probe_states.clone() },
+                    addr: runtime.sp("ha-scope", &scope_id) },
+            recv! { key: &ha_set_id, data: {"key": "default:default:10.0.0.0", "operation": "Set", "field_values": bfd_fvs},
+                    addr: crate::common_bridge_sp::<BfdSessionTable>(&runtime.get_swbus_edge()) },
+            recv! { key: &ha_set_id, data: {"key": "default:default:10.0.1.0", "operation": "Set", "field_values": bfd_fvs},
+                    addr: crate::common_bridge_sp::<BfdSessionTable>(&runtime.get_swbus_edge()) },
+
+            // === Phase 2: DPU HA Set State "down" sets dp_channel_is_alive to false ===
+            send! { key: DpuDashHaSetState::table_name(), data: { "key": &ha_set_id, "operation": "Set", "field_values": dpu_ha_set_state_down_fvs } },
+            recv! { key: &ha_set_id, data: {"key": &ha_set_id, "operation": "Set", "field_values": ha_set_obj_fvs},
+                    addr: crate::common_bridge_sp::<DashHaSetTable>(&runtime.get_swbus_edge()) },
+            recv! { key: HaSetActorState::msg_key(&ha_set_id), data: { "up": false, "ha_set": &ha_set_obj, "vdpu_ids": vec![vdpu0_id.clone(), vdpu1_id.clone()], "pinned_vdpu_bfd_probe_states": ha_set_cfg.pinned_vdpu_bfd_probe_states.clone() },
+                    addr: runtime.sp("ha-scope", &scope_id) },
+
+            // === Phase 3: HA scope Connecting resets dp_channel_is_alive to true ===
+            send! { key: HaScopeActorState::msg_key(&scope_id),
+                    data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connecting.as_str_name(), "timestamp": 12345i64, "term": "0", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id },
+                    addr: runtime.sp("ha-scope", &scope_id) },
+            // Verify dp_channel_is_alive is now true again (up = true)
+            recv! { key: &ha_set_id, data: {"key": &ha_set_id, "operation": "Set", "field_values": ha_set_obj_fvs},
+                    addr: crate::common_bridge_sp::<DashHaSetTable>(&runtime.get_swbus_edge()) },
+            recv! { key: HaSetActorState::msg_key(&ha_set_id), data: { "up": true, "ha_set": &ha_set_obj, "vdpu_ids": vec![vdpu0_id.clone(), vdpu1_id.clone()], "pinned_vdpu_bfd_probe_states": ha_set_cfg.pinned_vdpu_bfd_probe_states.clone() },
+                    addr: runtime.sp("ha-scope", &scope_id) },
 
             // === Phase 4: Cleanup ===
             send! { key: HaSetActor::table_name(), data: { "key": HaSetActor::table_name(), "operation": "Del", "field_values": ha_set_cfg_fvs },

--- a/crates/hamgrd/src/actors/test.rs
+++ b/crates/hamgrd/src/actors/test.rs
@@ -717,9 +717,11 @@ pub fn update_npu_ha_scope_state_by_dpu_scope_state(
     npu_ha_scope_state: &mut NpuDashHaScopeState,
     dpu_ha_scope_state: &DpuDashHaScopeState,
     target_ha_state: &str,
+    version: &str,
 ) {
+    npu_ha_scope_state.version = Some(version.to_string());
     npu_ha_scope_state.local_ha_state = Some(dpu_ha_scope_state.ha_role.clone());
-    npu_ha_scope_state.local_ha_state_last_updated_time_in_ms = Some(dpu_ha_scope_state.ha_role_start_time);
+    npu_ha_scope_state.local_ha_state_last_updated_time_in_ms = Some(dpu_ha_scope_state.ha_state_start_time);
     npu_ha_scope_state.local_ha_state_last_updated_reason = Some("dpu initiated".to_string());
     npu_ha_scope_state.local_target_asic_ha_state = Some(target_ha_state.to_string());
     npu_ha_scope_state.local_acked_asic_ha_state = Some(dpu_ha_scope_state.ha_role.clone());
@@ -753,8 +755,8 @@ pub fn make_dpu_ha_scope_state(role: &str) -> DpuDashHaScopeState {
         ha_term: Some("1".to_string()),
         // The DPU HA state.
         ha_state: role.to_string(),
-        // The time when HA state is moved into current one in milliseconds.
-        ha_state_start_time: now_in_millis(),
+        // The time when HA state is moved into current one in milliseconds. Choose different time from ha_role_start_time to make sure HA state change is detected.
+        ha_state_start_time: now_in_millis() + 1,
         activate_role_pending: false,
         flow_reconcile_pending: false,
         brainsplit_recover_pending: false,

--- a/crates/hamgrd/src/db_structs.rs
+++ b/crates/hamgrd/src/db_structs.rs
@@ -461,6 +461,8 @@ pub struct DpuResetInfo {
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Default, Clone, SonicDb)]
 #[sonicdb(table_name = "DASH_HA_SCOPE_STATE", key_separator = "|", db_name = "STATE_DB")]
 pub struct NpuDashHaScopeState {
+    // Config version.
+    pub version: Option<String>,
     // HA scope creation time in milliseconds.
     pub creation_time_in_ms: i64, /*todo: where is this from */
     // Last heartbeat time in milliseconds. This is used for leak detection.


### PR DESCRIPTION
### What I did
Combined cherry-pick of #167 and #175 onto `202605`.

This supersedes the two separate auto cherry-pick PRs that mssonicbld opened:
- #191 — `[action] [PR:167] Add version to npu DASH_HA_SCOPE_STATE`
- #190 — `[action] [PR:175] Fix HA set actor's programming of vnet_route`

### Why
#191 alone fails CI on 202605 with:

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
   --> crates/hamgrd/src/actors/ha_scope/mod.rs:567:13
```

Root cause: #167 added a `version: &str` 4th parameter to `update_npu_ha_scope_state_by_dpu_scope_state` and updated the call sites that existed in its diff context, but one call site (introduced earlier on master by #164 / on 202605 by its cherry-pick) was first bumped to the 4-arg form by a hunk inside **#175** (because #175 was authored after #167 landed). On 202605, neither #167 nor #175 was in yet, so the auto cherry-pick of #167 alone left `mod.rs:567` at the old 3-arg form.

Picking #175 alongside #167 closes the gap — all 4 call sites in `mod.rs` now match the new signature.

### How I verified it
- Both upstream commits cherry-picked cleanly onto `202605` (no conflicts).
- Verified the function signature in `crates/hamgrd/src/actors/test.rs` now has the `version: &str` parameter.
- Verified all 4 call sites in `crates/hamgrd/src/actors/ha_scope/mod.rs` (lines 272, 282, 407, 567) pass the new 4th argument.
- Will rely on this PR's CI for the full Rust build + tests on 202605.

### Notes for reviewers
- Once this merges, please close #190 and #191 as superseded.
- Original authorship preserved on both commits; DCO sign-offs intact.
