### PR TITLE
[NPU-driven HA] Gate NPU HA scope transitions on peer's acked ASIC role

### DIFF
--- a/crates/hamgrd/src/actors/ha_scope/base.rs
+++ b/crates/hamgrd/src/actors/ha_scope/base.rs
@@ -81,6 +81,7 @@ impl HaScopeBase {
             "0",
             &self.vdpu_id,
             self.peer_vdpu_id.as_deref().unwrap_or(""),
+            "",
         ) {
             if let Some(ha_set_id) = self.get_haset_id() {
                 outgoing.send(outgoing.from_my_sp(HaSetActor::name(), &ha_set_id), msg);

--- a/crates/hamgrd/src/actors/ha_scope/mod.rs
+++ b/crates/hamgrd/src/actors/ha_scope/mod.rs
@@ -1074,8 +1074,9 @@ mod test {
                         }},
 
                 // Expect HaScopeActorState: Destroying -> Dead
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
+                // The actor now reports its own ASIC-acked role ("dead") in the state update.
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id, "acked_asic_ha_state": "dead" }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id, "acked_asic_ha_state": "dead" }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
 
                 // Delete the HA scope config entry
                 send! { key: HaScopeConfig::table_name(), data: { "key": &scope_id, "operation": "Del",
@@ -1235,7 +1236,11 @@ mod test {
                 recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::SwitchingToStandalone.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
                 recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::SwitchingToStandalone.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
 
-                // EnterStandalone self-notification is processed immediately:
+                // The active node waits in SwitchingToStandalone until the peer's ASIC acks the dead role.
+                // Mock the peer completing its shutdown by broadcasting Dead with acked_asic_ha_state="dead".
+                send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": "", "peer_vdpu_id": "", "acked_asic_ha_state": "dead" } },
+
+                // EnterStandalone self-notification is then processed:
                 // Expect DPU DASH_HA_SCOPE_TABLE update with standalone role and incremented term
                 recv! { key: &ha_set_id, data: {
                         "key": &ha_set_id,
@@ -1319,9 +1324,10 @@ mod test {
                 send! { key: VoteRequest::msg_key(&peer_scope_id), data: { "dst_actor_id": &scope_id, "term": "0", "state": HaState::Connecting.as_str_name(), "desired_state": DesiredHaState::Unspecified.as_str_name() }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id) },
                 recv! { key: VoteReply::msg_key(&scope_id), data: { "dst_actor_id": &peer_scope_id, "response": "BecomeStandby" }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id) },
 
-                // New peer transitions to InitializingToStandby and broadcasts state
-                // This triggers PeerStateChanged on the Standalone node → transitions to Active
-                send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "0", "vdpu_id": "", "peer_vdpu_id": "" } },
+                // New peer transitions to InitializingToStandby and its ASIC acks the standby role.
+                // This triggers PeerStateChanged on the Standalone node, and because the peer's
+                // acked ASIC role is now standby, the Standalone node transitions to Active.
+                send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "0", "vdpu_id": "", "peer_vdpu_id": "", "acked_asic_ha_state": "standby" } },
 
                 // Expect DPU HA scope table update with Active role and term=3
                 recv! { key: &ha_set_id, data: {
@@ -1649,8 +1655,9 @@ mod test {
             let commands = [
                 // Mock the peer accepting the switchover (Fin response)
                 send! { key: SwitchoverRequest::msg_key(&peer_scope_id), data: { "dst_actor_id": &scope_id, "switchover_id": "", "flag": "Fin" } },
-                // Mock peer state change to SwitchingToStandby
-                send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::SwitchingToStandby.as_str_name(), "term": "1", "vdpu_id": "", "peer_vdpu_id": "" } },
+                // Mock peer state change to SwitchingToStandby with its ASIC having acked the standby role.
+                // The switchover to active completes only when the peer's ASIC acks the standby role.
+                send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::SwitchingToStandby.as_str_name(), "term": "1", "vdpu_id": "", "peer_vdpu_id": "", "acked_asic_ha_state": "standby" } },
                 // Expect DPU DASH_HA_SCOPE_TABLE update with active role and new term
                 recv! { key: &ha_set_id, data: {
                         "key": &ha_set_id,
@@ -2499,6 +2506,10 @@ mod test {
                 recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::SwitchingToStandalone.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
                 recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::SwitchingToStandalone.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
 
+                // The active node waits in SwitchingToStandalone until the peer's ASIC acks the dead role.
+                // Mock the peer completing its shutdown by broadcasting Dead with acked_asic_ha_state="dead".
+                send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": "", "peer_vdpu_id": "", "acked_asic_ha_state": "dead" } },
+
                 recv! { key: &ha_set_id, data: {
                         "key": &ha_set_id,
                         "operation": "Set",
@@ -2584,9 +2595,10 @@ mod test {
                 send! { key: VoteRequest::msg_key(&new_peer_scope_id), data: { "dst_actor_id": &scope_id, "term": "0", "state": HaState::Connecting.as_str_name(), "desired_state": DesiredHaState::Unspecified.as_str_name() }, addr: runtime.sp(HaScopeActor::name(), &new_peer_scope_id) },
                 recv! { key: VoteReply::msg_key(&scope_id), data: { "dst_actor_id": &new_peer_scope_id, "response": "BecomeStandby" }, addr: runtime.sp(HaScopeActor::name(), &new_peer_scope_id) },
 
-                // New peer transitions to InitializingToStandby and broadcasts state
-                // This triggers PeerStateChanged on the Standalone node → transitions to Active
-                send! { key: HaScopeActorState::msg_key(&new_peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "0", "vdpu_id": "", "peer_vdpu_id": "" } },
+                // New peer transitions to InitializingToStandby and its ASIC acks the standby role.
+                // This triggers PeerStateChanged on the Standalone node, and because the peer's
+                // acked ASIC role is now standby, the Standalone node transitions to Active.
+                send! { key: HaScopeActorState::msg_key(&new_peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "0", "vdpu_id": "", "peer_vdpu_id": "", "acked_asic_ha_state": "standby" } },
 
                 // Expect DPU HA scope table update with Active role and term=3
                 recv! { key: &ha_set_id, data: {
@@ -2778,8 +2790,9 @@ mod test {
                 // Side effect 3: broadcast the persisted (current) HA state to the peer
                 // and ha-set actors. `drive_npu_state_machine` sends the persisted state,
                 // not a new state, since rehydration short-circuits the FSM transition.
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Active.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Active.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
+                // The broadcast also carries the persisted ASIC-acked role ("active").
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Active.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id, "acked_asic_ha_state": "active" }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Active.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id, "acked_asic_ha_state": "active" }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
             ];
 
             test::run_commands(&runtime, runtime.sp(HaScopeActor::name(), &scope_id), &commands).await;
@@ -2968,8 +2981,10 @@ mod test {
             // ============================================================
             #[rustfmt::skip]
             let commands = [
-                // Peer broadcasts Dead state (forced shutdown — no graceful ShutdownRequest)
-                send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": "", "peer_vdpu_id": "" } },
+                // Peer broadcasts Dead state (forced shutdown — no graceful ShutdownRequest),
+                // including its ASIC-acked role ("dead"). The Active node detects the peer's
+                // acked dead role and enters standalone directly.
+                send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": "", "peer_vdpu_id": "", "acked_asic_ha_state": "dead" } },
 
                 // Expect HaScopeActorState: Active -> SwitchingToStandalone
                 recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::SwitchingToStandalone.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
@@ -3249,8 +3264,9 @@ mod test {
                         }},
 
                 // Expect HaScopeActorState: Destroying -> Dead
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
+                // The actor now reports its own ASIC-acked role ("dead") in the state update.
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id, "acked_asic_ha_state": "dead" }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id, "acked_asic_ha_state": "dead" }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
             ];
 
             test::run_commands(&runtime, runtime.sp(HaScopeActor::name(), &scope_id), &commands).await;
@@ -3281,16 +3297,16 @@ mod test {
                 // Expect a PeerHeartbeat to be triggered
                 recv! { key: PeerHeartbeat::msg_key(&scope_id), data: { "dst_actor_id": &peer_scope_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id) },
                 // Expect HaScopeActorState: Dead -> Connecting
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connecting.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connecting.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connecting.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp,acked_asic_ha_state" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connecting.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp,acked_asic_ha_state" },
 
                 // Mock the peer HA scope reporting Active state (peer is still active)
                 send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::Active.as_str_name(), "term": "1", "vdpu_id": "", "peer_vdpu_id": "" } },
                 // Expect a VoteRequest to be sent
                 recv!( key: VoteRequest::msg_key(&scope_id), data: { "dst_actor_id": &peer_scope_id, "term": "1", "state": HaState::Connecting.as_str_name(), "desired_state": DesiredHaState::Unspecified.as_str_name() }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id) ),
                 // Expect HaScopeActorState: Connecting -> Connected
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connected.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connected.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connected.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp,acked_asic_ha_state" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Connected.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp,acked_asic_ha_state" },
 
                 // Mock a VoteReply: BecomeStandby (peer is Active, so this node becomes Standby again)
                 send! { key: VoteReply::msg_key(&peer_scope_id), data: { "dst_actor_id": &scope_id, "response": "BecomeStandby" } },
@@ -3308,14 +3324,14 @@ mod test {
                         addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())
                     },
                 // Expect HaScopeActorState: Connected -> InitializingToStandby
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp,acked_asic_ha_state" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::InitializingToStandby.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp,acked_asic_ha_state" },
 
                 // Mock a bulkSyncCompleted message from the peer
                 send! { key: BulkSyncUpdate::msg_key(&peer_scope_id), data: { "dst_actor_id": &scope_id, "finished": true }},
                 // Expect HaScopeActorState: InitializingToStandby -> PendingStandbyActivation
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::PendingStandbyActivation.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::PendingStandbyActivation.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::PendingStandbyActivation.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp,acked_asic_ha_state" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::PendingStandbyActivation.as_str_name(), "term": "1", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp,acked_asic_ha_state" },
                 // Mock the HaScopeActorState from the peer with term (peer is Active with term=2)
                 send! { key: HaScopeActorState::msg_key(&peer_scope_id), data: { "timestamp": 0, "owner": 0, "new_state": HaState::Active.as_str_name(), "term": "2", "vdpu_id": "", "peer_vdpu_id": "" } },
             ];
@@ -3356,8 +3372,8 @@ mod test {
                         addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())
                     },
                 // Expect HaScopeActorState: PendingStandbyActivation -> Standby
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Standby.as_str_name(), "term": "2", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Standby.as_str_name(), "term": "2", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Standby.as_str_name(), "term": "2", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp,acked_asic_ha_state" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Standby.as_str_name(), "term": "2", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp,acked_asic_ha_state" },
             ];
 
             test::run_commands(&runtime, runtime.sp(HaScopeActor::name(), &scope_id), &commands).await;
@@ -3406,8 +3422,8 @@ mod test {
                         addr: crate::common_bridge_sp::<DashHaScopeTable>(&runtime.get_swbus_edge())
                     },
 
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "2", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
-                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "2", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "2", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id, "acked_asic_ha_state": "dead" }, addr: runtime.sp(HaScopeActor::name(), &peer_scope_id), exclude: "timestamp" },
+                recv! { key: HaScopeActorState::msg_key(&scope_id), data: { "owner": HaOwner::Switch as i32, "new_state": HaState::Dead.as_str_name(), "term": "2", "vdpu_id": &vdpu0_id, "peer_vdpu_id": &vdpu1_id, "acked_asic_ha_state": "dead" }, addr: runtime.sp(HaSetActor::name(), &ha_set_id), exclude: "timestamp" },
 
                 // Delete the HA scope config entry
                 send! { key: HaScopeConfig::table_name(), data: { "key": &scope_id, "operation": "Del",

--- a/crates/hamgrd/src/actors/ha_scope/npu.rs
+++ b/crates/hamgrd/src/actors/ha_scope/npu.rs
@@ -367,6 +367,7 @@ impl NpuHaScopeActor {
             npu_ha_scope_state.local_target_term.as_deref().unwrap_or("0"),
             &self.base.vdpu_id,
             self.base.peer_vdpu_id.as_deref().unwrap_or(""),
+            npu_ha_scope_state.local_acked_asic_ha_state.as_deref().unwrap_or(""),
         )?;
         outgoing.send(entry.source.clone(), msg);
 
@@ -718,6 +719,11 @@ impl NpuHaScopeActor {
         npu_ha_scope_state.peer_ha_state = Some(change.new_state);
         npu_ha_scope_state.peer_ha_state_last_updated_time_in_ms = Some(change.timestamp);
         npu_ha_scope_state.peer_term = Some(change.term);
+        npu_ha_scope_state.peer_acked_asic_ha_state = if change.acked_asic_ha_state.is_empty() {
+            None
+        } else {
+            Some(change.acked_asic_ha_state.clone())
+        };
         if self.target_ha_scope_state == Some(TargetState::Standby) {
             // Standby HA scope should follow the change of the peer term
             npu_ha_scope_state.local_target_term = npu_ha_scope_state.peer_term.clone();
@@ -1195,6 +1201,16 @@ impl NpuHaScopeActor {
             .unwrap_or(HaState::Unspecified)
     }
 
+    /// Return the HA role acked by the peer's ASIC (e.g. "active", "standby"), as
+    /// reported in the peer's most recent HA Scope State Update. Returns an empty
+    /// string when the peer's acked role is unknown.
+    fn current_npu_peer_acked_asic_ha_state(&self, internal: &Internal) -> String {
+        self.base
+            .get_npu_ha_scope_state(internal)
+            .and_then(|scope| scope.peer_acked_asic_ha_state)
+            .unwrap_or_default()
+    }
+
     /// Restore `target_ha_scope_state` from persisted `local_target_asic_ha_state` in
     /// STATE_DB. This is used during rehydration because `target_ha_scope_state` is
     /// in-memory only and lost on crash.
@@ -1352,8 +1368,10 @@ impl NpuHaScopeActor {
                 self.send_vote_request_to_peer(state, false)?;
             }
             HaState::InitializingToActive => {
-                // If the peer is already in InitializingToStandby
-                if self.current_npu_peer_ha_state(state.internal()) == HaState::InitializingToStandby {
+                // If the peer's ASIC has already acked the standby role
+                if self.current_npu_peer_acked_asic_ha_state(state.internal())
+                    == ha_role_to_string(HaRole::Standby.as_str_name())
+                {
                     // Note: it does not really move the HA scope into Active immediately since we need SDN approvals
                     self.send_self_notification(state, "EnterActive", 0)?;
                 }
@@ -1378,10 +1396,19 @@ impl NpuHaScopeActor {
                 } else if *event == HaEvent::PeerLost {
                     // Peer DPU lost
                     self.send_self_notification(state, "EnterStandalone", 0)?;
-                } else if *event == HaEvent::PeerShutdownRequested
-                    || self.current_npu_peer_ha_state(state.internal()) == HaState::Dead
+                } else if *event == HaEvent::PeerShutdownRequested {
+                    if self.current_npu_peer_acked_asic_ha_state(state.internal())
+                        == ha_role_to_string(HaRole::Dead.as_str_name())
+                    {
+                        // Peer DPU planned shutdown and already dead — enter standalone
+                        self.send_self_notification(state, "EnterStandalone", 0)?;
+                    }
+                    // Else wait for peer to become Dead
+                } else if *event == HaEvent::PeerStateChanged
+                    && self.current_npu_peer_acked_asic_ha_state(state.internal())
+                        == ha_role_to_string(HaRole::Dead.as_str_name())
                 {
-                    // Peer DPU planned shutdown or forced shutdown
+                    // Peer DPU forced shutdown — enter standalone
                     self.send_self_notification(state, "EnterStandalone", 0)?;
                 } else {
                     // Send DPURequestEnterStandalone to peer with local health signals
@@ -1684,9 +1711,10 @@ impl NpuHaScopeActor {
                 if *event == HaEvent::PeerLost {
                     Some((HaState::SwitchingToStandalone, "peer lost during switchover to standby"))
                 } else if *event == HaEvent::PeerStateChanged
-                    && self.current_npu_peer_ha_state(state.internal()) == HaState::Active
+                    && self.current_npu_peer_acked_asic_ha_state(state.internal())
+                        == ha_role_to_string(HaRole::Active.as_str_name())
                 {
-                    Some((HaState::Standby, "peer has been active"))
+                    Some((HaState::Standby, "peer acked active role"))
                 } else {
                     None
                 }
@@ -1715,9 +1743,10 @@ impl NpuHaScopeActor {
                 if *event == HaEvent::PeerLost {
                     Some((HaState::SwitchingToStandalone, "peer lost during switchover to active"))
                 } else if *event == HaEvent::PeerStateChanged
-                    && self.current_npu_peer_ha_state(state.internal()) == HaState::SwitchingToStandby
+                    && self.current_npu_peer_acked_asic_ha_state(state.internal())
+                        == ha_role_to_string(HaRole::Standby.as_str_name())
                 {
-                    Some((HaState::Active, "switchover to active complete"))
+                    Some((HaState::Active, "peer acked standby role"))
                 } else if *event == HaEvent::SwitchoverFailed {
                     Some((HaState::Standby, "switchover failed"))
                 } else {
@@ -1743,11 +1772,12 @@ impl NpuHaScopeActor {
             }
             HaState::Standalone => {
                 // Transition out of Standalone on peer state updates.
-                // When the peer starts initializing to standby, this node becomes Active.
+                // When the peer's ASIC acks the standby role, this node becomes Active.
                 if *event == HaEvent::PeerStateChanged
-                    && self.current_npu_peer_ha_state(state.internal()) == HaState::InitializingToStandby
+                    && self.current_npu_peer_acked_asic_ha_state(state.internal())
+                        == ha_role_to_string(HaRole::Standby.as_str_name())
                 {
-                    Some((HaState::Active, "peer initializing to standby"))
+                    Some((HaState::Active, "peer acked standby role"))
                 } else {
                     None
                 }
@@ -1759,6 +1789,11 @@ impl NpuHaScopeActor {
                         TargetState::Standby => Some((HaState::Standby, "failed to enter standalone")),
                         _ => None, // Target Dead and Standalone case should not be handled at this place
                     }
+                } else if *event == HaEvent::PeerStateChanged
+                    && self.current_npu_peer_acked_asic_ha_state(state.internal())
+                        == ha_role_to_string(HaRole::Dead.as_str_name())
+                {
+                    Some((HaState::Standalone, "peer acked dead role"))
                 } else {
                     None
                 }
@@ -1785,6 +1820,10 @@ impl NpuHaScopeActor {
         let (internal, _incoming, outgoing) = state.get_all();
         let npu_state = self.base.get_npu_ha_scope_state(internal);
         let local_target_term = npu_state.as_ref().and_then(|s| s.local_target_term.as_deref());
+        let acked_asic_ha_state = npu_state
+            .as_ref()
+            .and_then(|s| s.local_acked_asic_ha_state.as_deref())
+            .unwrap_or("");
         let owner = self
             .base
             .dash_ha_scope_config
@@ -1803,6 +1842,7 @@ impl NpuHaScopeActor {
             term,
             &self.base.vdpu_id,
             self.base.peer_vdpu_id.as_deref().unwrap_or(""),
+            acked_asic_ha_state,
         ) {
             if let Some(peer_sp) = self.peer_sp() {
                 outgoing.send(peer_sp, msg.clone());

--- a/crates/hamgrd/src/db_structs.rs
+++ b/crates/hamgrd/src/db_structs.rs
@@ -497,6 +497,8 @@ pub struct NpuDashHaScopeState {
     pub peer_ha_state_last_updated_time_in_ms: Option<i64>,
     // The current term in peer DPU.
     pub peer_term: Option<String>,
+    // The HA role acked by the peer's ASIC (e.g. "active", "standby"). None when unknown.
+    pub peer_acked_asic_ha_state: Option<String>,
 
     // The state of local vDPU midplane. The value can be "unknown", "up", "down".
     pub local_vdpu_midplane_state: DpuPmonStateType,

--- a/crates/hamgrd/src/ha_actor_messages.rs
+++ b/crates/hamgrd/src/ha_actor_messages.rs
@@ -187,9 +187,13 @@ pub struct HaScopeActorState {
     pub term: String,
     pub vdpu_id: String,
     pub peer_vdpu_id: String,
+    // The HA role acked by the sender's ASIC (e.g. "active", "standby"). Empty when unknown.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub acked_asic_ha_state: String,
 }
 
 impl HaScopeActorState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_actor_msg(
         my_id: &str,
         owner: i32,
@@ -198,6 +202,7 @@ impl HaScopeActorState {
         term: &str,
         vdpu_id: &str,
         peer_vdpu_id: &str,
+        acked_asic_ha_state: &str,
     ) -> Result<ActorMessage> {
         ActorMessage::new(
             Self::msg_key(my_id),
@@ -208,6 +213,7 @@ impl HaScopeActorState {
                 term: term.to_string(),
                 vdpu_id: vdpu_id.to_string(),
                 peer_vdpu_id: peer_vdpu_id.to_string(),
+                acked_asic_ha_state: acked_asic_ha_state.to_string(),
             },
         )
     }


### PR DESCRIPTION
### Description of PR

Summary:
NPU-driven HA scope state transitions previously keyed off the peer's HA
state-machine state (`peer_ha_state`). That value reflects where the peer's
control plane *thinks* it is, not what the peer's DPU/ASIC has actually
committed to. This PR propagates the peer's ASIC-acked HA role between HA
scope actors and uses it to gate the role-sensitive state transitions, so a
node only advances once it has positive confirmation of the peer's committed
role.

Reviewer entry point: `crates/hamgrd/src/actors/ha_scope/npu.rs` —
`next_state()` and `apply_pending_state_side_effects()`.

Dependencies: none.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

`peer_ha_state` is the peer's FSM state and can lead/lag the role its ASIC has
actually activated. Driving transitions such as switchover completion and
standalone entry off the FSM state can move a node forward before the peer's
hardware has committed, risking transient dual-active / split-brain windows.
The ASIC-acked role (`local_acked_asic_ha_state`) is the authoritative,
hardware-confirmed signal and is a safer gate for these transitions.

#### How did you do it?

- Added an `acked_asic_ha_state` field to the `HaScopeActorState` message
  (the "HA Scope State Update"), carrying the sender's ASIC-acked HA role.
  It uses serde `default` + skip-if-empty so it is backward compatible with
  peers/messages that don't set it.
- Added `peer_acked_asic_ha_state` to `NpuDashHaScopeState`, populated in
  `handle_ha_state_change` from the peer's update.
- `broadcast_ha_scope_state` and the heartbeat reply now include the local
  ASIC-acked role; the base first-config broadcast sends an empty value.
- Re-gated the following transitions in `next_state` on the peer's acked
  ASIC role instead of `peer_ha_state`:
    - `SwitchingToStandby   -> Standby`    (peer acked active)
    - `SwitchingToActive    -> Active`     (peer acked standby)
    - `Standalone           -> Active`     (peer acked standby)
    - `SwitchingToStandalone -> Standalone` (peer acked dead)
- In `apply_pending_state_side_effects`, entering standalone from
  `SwitchingToStandalone` now triggers when the peer's ASIC acks the dead
  role, covering both forced shutdown and the two-step planned-shutdown
  completion; the `InitializingToActive` fast path checks the peer's acked
  standby role.

#### How did you verify/test it?

Built the workspace and ran the full `hamgrd` unit-test suite inside the
`sonic-dash-ha` build container (Ubuntu 22.04 + locally built
`libswsscommon`): `cargo build --workspace` succeeds and
`cargo test -p hamgrd` passes (41 tests, 0 failures). The `ha_scope` NPU
tests were updated so peers broadcast their acked role, including the
two-step planned-shutdown flow where the active node waits for the peer to
ack the dead role before entering standalone.

#### Any platform specific information?

None. Change is confined to the `hamgrd` NPU-driven HA scope logic and the
`HaScopeActorState`/`NpuDashHaScopeState` data structures. The new message
field is optional/serde-default, so it interoperates with peers that don't
populate it.

### Documentation

No wiki/documentation changes. This is an internal behavioral fix to the HA
scope state machine; existing DASH HA HLD references remain applicable.