### PR TITLE
[NPU-driven HA] Add the gating on control plane state back to the state machine

### DIFF
--- a/crates/hamgrd/src/actors/ha_scope/npu.rs
+++ b/crates/hamgrd/src/actors/ha_scope/npu.rs
@@ -1372,9 +1372,11 @@ impl NpuHaScopeActor {
                 self.send_vote_request_to_peer(state, false)?;
             }
             HaState::InitializingToActive => {
-                // If the peer's ASIC has already acked the standby role
+                // If the peer's ASIC has already acked the standby role and the peer
+                // control plane reports InitializingToStandby
                 if self.current_npu_peer_acked_asic_ha_state(state.internal())
                     == ha_role_to_string(HaRole::Standby.as_str_name())
+                    && self.current_npu_peer_ha_state(state.internal()) == HaState::InitializingToStandby
                 {
                     // Note: it does not really move the HA scope into Active immediately since we need SDN approvals
                     self.send_self_notification(state, "EnterActive", 0)?;
@@ -1403,6 +1405,7 @@ impl NpuHaScopeActor {
                 } else if *event == HaEvent::PeerShutdownRequested {
                     if self.current_npu_peer_acked_asic_ha_state(state.internal())
                         == ha_role_to_string(HaRole::Dead.as_str_name())
+                        && self.current_npu_peer_ha_state(state.internal()) == HaState::Dead
                     {
                         // Peer DPU planned shutdown and already dead — enter standalone
                         self.send_self_notification(state, "EnterStandalone", 0)?;
@@ -1411,6 +1414,7 @@ impl NpuHaScopeActor {
                 } else if *event == HaEvent::PeerStateChanged
                     && self.current_npu_peer_acked_asic_ha_state(state.internal())
                         == ha_role_to_string(HaRole::Dead.as_str_name())
+                    && self.current_npu_peer_ha_state(state.internal()) == HaState::Dead
                 {
                     // Peer DPU forced shutdown — enter standalone
                     self.send_self_notification(state, "EnterStandalone", 0)?;
@@ -1717,8 +1721,9 @@ impl NpuHaScopeActor {
                 } else if *event == HaEvent::PeerStateChanged
                     && self.current_npu_peer_acked_asic_ha_state(state.internal())
                         == ha_role_to_string(HaRole::Active.as_str_name())
+                    && self.current_npu_peer_ha_state(state.internal()) == HaState::Active
                 {
-                    Some((HaState::Standby, "peer acked active role"))
+                    Some((HaState::Standby, "peer become active"))
                 } else {
                     None
                 }
@@ -1749,6 +1754,7 @@ impl NpuHaScopeActor {
                 } else if *event == HaEvent::PeerStateChanged
                     && self.current_npu_peer_acked_asic_ha_state(state.internal())
                         == ha_role_to_string(HaRole::Standby.as_str_name())
+                    && self.current_npu_peer_ha_state(state.internal()) == HaState::SwitchingToStandby
                 {
                     Some((HaState::Active, "peer acked standby role"))
                 } else if *event == HaEvent::SwitchoverFailed {
@@ -1780,8 +1786,9 @@ impl NpuHaScopeActor {
                 if *event == HaEvent::PeerStateChanged
                     && self.current_npu_peer_acked_asic_ha_state(state.internal())
                         == ha_role_to_string(HaRole::Standby.as_str_name())
+                    && self.current_npu_peer_ha_state(state.internal()) == HaState::InitializingToStandby
                 {
-                    Some((HaState::Active, "peer acked standby role"))
+                    Some((HaState::Active, "peer is ready to become standby"))
                 } else {
                     None
                 }
@@ -1796,8 +1803,9 @@ impl NpuHaScopeActor {
                 } else if *event == HaEvent::PeerStateChanged
                     && self.current_npu_peer_acked_asic_ha_state(state.internal())
                         == ha_role_to_string(HaRole::Dead.as_str_name())
+                    && self.current_npu_peer_ha_state(state.internal()) == HaState::Dead
                 {
-                    Some((HaState::Standalone, "peer acked dead role"))
+                    Some((HaState::Standalone, "peer shutdown"))
                 } else {
                     None
                 }


### PR DESCRIPTION
### Description of PR

Summary:
This PR re-adds the gating on the peer's **control plane HA state** to the NPU HA scope state machine. Several state transitions in `NpuHaScopeActor` previously advanced based solely on the peer's **ASIC-acked HA role** (`current_npu_peer_acked_asic_ha_state`). This could allow the local scope to advance prematurely when the ASIC role had been acknowledged but the peer's control plane had not yet reported the corresponding HA state. Each affected transition now additionally requires the peer's control plane state (`current_npu_peer_ha_state`) to match the expected `HaState`, ensuring both the data-plane (ASIC) and control-plane views agree before transitioning.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?
Relying only on the ASIC-acked role to drive HA state transitions was insufficient: the ASIC role and the peer control plane state could be temporarily inconsistent, causing the state machine to move to the next state before the peer's control plane was actually ready. This adds the missing control-plane gating condition back to the state machine.

#### How did you do it?
In `crates/hamgrd/src/actors/ha_scope/npu.rs`, added `&& self.current_npu_peer_ha_state(...) == HaState::<expected>` alongside the existing `current_npu_peer_acked_asic_ha_state` checks for the following transitions:
- `InitializingToActive` → requires peer control plane `InitializingToStandby`
- `PeerShutdownRequested` (planned shutdown) → requires peer `Dead`
- `PeerStateChanged` (forced shutdown) → requires peer `Dead`
- Peer becomes active → requires peer `Active`
- Peer acks standby (switchover) → requires peer `SwitchingToStandby`
- Peer ready to become standby → requires peer `InitializingToStandby`
- Peer shutdown → standalone → requires peer `Dead`

Also clarified a few transition reason strings (e.g. "peer acked active role" → "peer become active", "peer acked dead role" → "peer shutdown").

#### How did you verify/test it?
<!-- Add the relevant unit/integration test runs, e.g. `cargo test -p hamgrd`, or testbed verification. -->

#### Any platform specific information?
None. `hamgrd` is Linux-only and requires `libswsscommon`, but this change is pure state-machine logic.

### Documentation
No documentation changes. Link to the relevant SONiC DASH HA state-machine design doc if applicable.
