### PR TITLE
Added checks to only enable HA set actor state update after HA set table entry is programmed

### DIFF
--- a/crates/hamgrd/src/actors/ha_scope/npu.rs
+++ b/crates/hamgrd/src/actors/ha_scope/npu.rs
@@ -1500,6 +1500,11 @@ impl NpuHaScopeActor {
         }
 
         let ha_set_id = self.base.get_haset_id().unwrap_or_default();
+        // Do not drive the state machine (which programs DASH_HA_SCOPE_TABLE, including the
+        // initial dead role) until the HA set actor has acked that DASH_HA_SET_TABLE is
+        // programmed. That ack is the HaSetActorState message: the HA set actor only emits it
+        // after it has issued the DASH_HA_SET_TABLE write, so its presence here guarantees the
+        // HA set entry is programmed before we program any dependent HA scope entry.
         let Some(_haset) = self.base.get_haset(state.incoming()) else {
             info!("HA-SET {} has not been initialized yet", &ha_set_id);
             return Ok(());

--- a/crates/hamgrd/src/actors/ha_set.rs
+++ b/crates/hamgrd/src/actors/ha_set.rs
@@ -34,6 +34,11 @@ pub struct HaSetActor {
     bridges: Vec<ConsumerBridge>,
     bfd_session_npu_ips: HashSet<String>,
     ha_scope_states: HashMap<String, CachedHaScopeState>,
+    /// Whether this actor has programmed the DASH_HA_SET_TABLE entry into the DPU.
+    /// The HaSetActorState message (which HA scope actors depend on to drive their
+    /// state machine) is only emitted once this is true, so that a dependent HA
+    /// scope never programs DASH_HA_SCOPE_TABLE before the HA set entry exists.
+    dash_ha_set_programmed: bool,
 }
 
 impl DbBasedActor for HaSetActor {
@@ -46,6 +51,7 @@ impl DbBasedActor for HaSetActor {
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states: HashMap::new(),
+            dash_ha_set_programmed: false,
         };
         Ok(actor)
     }
@@ -167,7 +173,7 @@ impl HaSetActor {
     }
 
     fn update_dash_ha_set_table(
-        &self,
+        &mut self,
         vdpus: &[VDpuStateExt],
         incoming: &Incoming,
         outgoing: &mut Outgoing,
@@ -184,6 +190,11 @@ impl HaSetActor {
 
         let msg = ActorMessage::new(self.id.clone(), &kfv)?;
         outgoing.send(outgoing.common_bridge_sp::<DashHaSetTable>(), msg);
+
+        // The DASH_HA_SET_TABLE write has now been issued to the DPU. From this point on the
+        // HaSetActorState message we emit below serves as the ack that dependent HA scope
+        // actors wait on before driving their state machine / programming DASH_HA_SCOPE_TABLE.
+        self.dash_ha_set_programmed = true;
 
         let vdpu_ids = self
             .dash_ha_set_config
@@ -210,7 +221,7 @@ impl HaSetActor {
         Ok(())
     }
 
-    fn delete_dash_ha_set_table(&self, vdpus: &[VDpuStateExt], outgoing: &mut Outgoing) -> Result<()> {
+    fn delete_dash_ha_set_table(&mut self, vdpus: &[VDpuStateExt], outgoing: &mut Outgoing) -> Result<()> {
         if !vdpus.iter().any(|vdpu_ext| vdpu_ext.vdpu.dpu.is_managed) {
             debug!("None of DPUs is managed by local HAMGRD. Skip dash_ha_set deletion");
             return Ok(());
@@ -224,6 +235,10 @@ impl HaSetActor {
 
         let msg = ActorMessage::new(self.id.clone(), &kfv)?;
         outgoing.send(outgoing.common_bridge_sp::<DashHaSetTable>(), msg);
+
+        // The DASH_HA_SET_TABLE entry is being removed; dependent HA scope actors must again
+        // wait for it to be reprogrammed before acting.
+        self.dash_ha_set_programmed = false;
 
         Ok(())
     }
@@ -878,6 +893,15 @@ impl HaSetActor {
             .ok_or_else(|| anyhow!("Entry not found for key: {}", key))?;
         let ActorRegistration { active, .. } = entry.msg.deserialize_data()?;
         if active {
+            // Only reply with the HaSetActorState ack once the DASH_HA_SET_TABLE entry has
+            // actually been programmed. A registration arriving before programming must not
+            // hand the HA scope actor an ha-set state it could act on prematurely (which would
+            // let it program DASH_HA_SCOPE_TABLE before the HA set entry exists). The HA scope
+            // will receive the state later via update_dash_ha_set_table once it is programmed.
+            if !self.dash_ha_set_programmed {
+                debug!("DASH_HA_SET_TABLE not programmed yet. Defer HaSetActorState reply to registration");
+                return Ok(());
+            }
             let Some(vdpus) = self.get_vdpus_if_ready(incoming) else {
                 return Ok(());
             };
@@ -1096,6 +1120,7 @@ mod test {
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states,
+            dash_ha_set_programmed: false,
         };
 
         assert_eq!(
@@ -1188,6 +1213,7 @@ mod test {
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states: HashMap::new(),
+            dash_ha_set_programmed: false,
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1396,6 +1422,7 @@ mod test {
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states: HashMap::new(),
+            dash_ha_set_programmed: false,
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1590,6 +1617,7 @@ mod test {
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states: HashMap::new(),
+            dash_ha_set_programmed: false,
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1749,6 +1777,7 @@ mod test {
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states: HashMap::new(),
+            dash_ha_set_programmed: false,
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1884,6 +1913,7 @@ mod test {
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states: HashMap::new(),
+            dash_ha_set_programmed: false,
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -1983,6 +2013,7 @@ mod test {
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states: HashMap::new(),
             ha_owner: HaOwner::Dpu,
+            dash_ha_set_programmed: false,
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -2092,6 +2123,7 @@ mod test {
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states: HashMap::new(),
+            dash_ha_set_programmed: false,
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);
@@ -2218,6 +2250,7 @@ mod test {
             bridges: Vec::new(),
             bfd_session_npu_ips: HashSet::new(),
             ha_scope_states: HashMap::new(),
+            dash_ha_set_programmed: false,
         };
 
         let handle = runtime.spawn(ha_set_actor, HaSetActor::name(), &ha_set_id);


### PR DESCRIPTION
### Description of PR

Summary:
Ensure the DPU's `DASH_HA_SCOPE_TABLE` entry is never programmed before the
`DASH_HA_SET_TABLE` entry it depends on. The HA set actor now only advertises its
`HaSetActorState` (the signal every HA scope actor gates on) **after** it has
programmed the `DASH_HA_SET_TABLE` entry, so a dependent HA scope actor cannot drive
its state machine — and program `DASH_HA_SCOPE_TABLE` (including the initial `dead`
role) — until the HA set entry exists.

Fixes # (issue) https://github.com/sonic-net/sonic-buildimage/issues/28073

**Background / where to start reviewing:**
- Start in [`crates/hamgrd/src/actors/ha_set.rs`](crates/hamgrd/src/actors/ha_set.rs):
  the new `dash_ha_set_programmed` flag on `HaSetActor` and the gating in
  `handle_haset_state_registration`.
- Then [`crates/hamgrd/src/actors/ha_scope/npu.rs`](crates/hamgrd/src/actors/ha_scope/npu.rs):
  the clarifying comment on the existing `get_haset` gate in `drive_npu_state_machine`.

**Dependencies:** none.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?

During a DPU reboot test on a SmartSwitch testbed, the initial `DASH_HA_SCOPE_TABLE` entry (with the `dead` role) was
observed being programmed **before** the initial `DASH_HA_SET_TABLE` entry that it
references. The DPU expects the HA set entry to exist before the HA scope entry, so
this ordering is incorrect.

Root cause: the HA scope actor only needs the in-memory `HaSetActorState` message to
drive its state machine and program `DASH_HA_SCOPE_TABLE` — it does not check whether
the HA set actor has actually written `DASH_HA_SET_TABLE` to the DPU. That
`HaSetActorState` could be delivered via the registration-reply path
(`HaSetActor::handle_haset_state_registration`), which replies with the cached state
**without** ever programming `DASH_HA_SET_TABLE`. As a result the HA scope actor could
program its (dead-role) scope entry before the HA set entry was written. The two
tables are also written by two independent actors through two independent
`ConsumerBridge` instances, so there is no inherent ordering guarantee between them.

#### How did you do it?

- Added a `dash_ha_set_programmed: bool` field to `HaSetActor`.
- Set it to `true` in `update_dash_ha_set_table` immediately after the
  `DASH_HA_SET_TABLE` write is issued to the DPU (and before the `HaSetActorState` is
  emitted to registered HA scope actors). Reset it to `false` in
  `delete_dash_ha_set_table` so scopes wait again if the entry is removed.
- In `handle_haset_state_registration`, defer the `HaSetActorState` reply until
  `dash_ha_set_programmed` is `true`. A registration that arrives before programming
  no longer hands the HA scope actor a state it could act on prematurely; the HA scope
  is instead notified later (proactively) via `update_dash_ha_set_table` once the entry
  is programmed. Because the registration record persists in the HA set actor's
  incoming state, no re-registration/retry is required from the scope.
- The NPU-driven HA scope state machine already early-returns in
  `drive_npu_state_machine` when `get_haset` returns `None`. Added a comment there
  documenting that the presence of `HaSetActorState` now means "the HA set entry is
  programmed," so the machine only functions after the ack.

Note: this change lives in the shared HA set actor, so it applies consistently to both
the NPU-driven and DPU-driven HA scope actors (both gate on receiving
`HaSetActorState`). No behavioral regression for DPU-driven mode — it gets the same
ordering guarantee.

Known limitation: "programmed" here means the HA set actor has **issued** the
producer-bridge write, not that it has been confirmed applied in the DPU APPL_DB. The
actor framework does not surface producer-bridge write acks back into actor logic, so a
true end-to-end APPL_DB write confirmation would require additional plumbing in
`swbus-actor`. This change removes the actual race that was hit (the registration-reply
path, which programmed nothing) and orders the two writes correctly in the normal path.

#### How did you verify/test it?

- Ran the full `hamgrd` unit test suite: `cargo test -p hamgrd` — 41 tests pass,
  including all `ha_set` and NPU/DPU-driven `ha_scope` tests.
- `cargo fmt` and `cargo clippy -p hamgrd --all-targets` are clean (no new warnings).
- Built the Debian package and deployed to both testbed switches
  across all `dash-hadpu0..3` containers, followed
  by `config reload`, to validate the corrected ordering during the DPU reboot test.

#### Any platform specific information?

SmartSwitch / DASH HA only. Affects `hamgrd` behavior on the switch NPU and the DPU
`DASH_HA_SET_TABLE` / `DASH_HA_SCOPE_TABLE` programming order.

### Documentation

No documentation/Wiki changes required. Behavior is internal to `hamgrd` actor
sequencing and does not change any external API or schema.
