### PR TITLE
hamgrd: ignore DPU HA set/scope state deletion messages

### DIFF
--- a/crates/hamgrd/src/actors/ha_scope/base.rs
+++ b/crates/hamgrd/src/actors/ha_scope/base.rs
@@ -160,6 +160,11 @@ impl HaScopeBase {
             }
         };
 
+        if kfv.operation == KeyOperation::Del {
+            debug!("Ignoring DASH_HA_SCOPE_STATE deletion for key={}", kfv.key);
+            return None;
+        }
+
         match swss_serde::from_field_values(&kfv.field_values) {
             Ok(state) => Some(state),
             Err(e) => {

--- a/crates/hamgrd/src/actors/ha_set.rs
+++ b/crates/hamgrd/src/actors/ha_set.rs
@@ -157,6 +157,11 @@ impl HaSetActor {
             }
         };
 
+        if kfv.operation == KeyOperation::Del {
+            debug!("Ignoring DASH_HA_SET_STATE deletion for key={}", kfv.key);
+            return None;
+        }
+
         match swss_serde::from_field_values(&kfv.field_values) {
             Ok(state) => Some((kfv.key, state)),
             Err(e) => {


### PR DESCRIPTION
## Description of PR
`get_dpu_ha_set_state` and `get_dpu_ha_scope_state` previously deserialized every incoming `DASH_HA_SET_STATE` / `DASH_HA_SCOPE_STATE` message regardless of the DB operation. A `Del` message carries empty field values, so it could be misinterpreted as an (empty) state update rather than being ignored.

This PR adds an explicit `KeyOperation::Del` check to both accessors so deletion notifications are logged at debug level and skipped (returning `None`), which causes the callers to ignore them.

## Type of change
- [x] Bug fix
Fix https://github.com/sonic-net/sonic-buildimage/issues/28162

## Approach
**How it works:** Both accessor functions now inspect `kfv.operation` after deserializing the `KeyOpFieldValues`. When the operation is `KeyOperation::Del`, they return `None` early instead of attempting to deserialize the (empty) field values.

**How it was verified:** `cargo test -p hamgrd` — all 41 unit tests pass, including the ha_set and ha_scope NPU/DPU suites.