### PR TITLE
swbus: log receive stream closure as warning

### DIFF
--- a/crates/swbus-core/src/mux/conn_worker.rs
+++ b/crates/swbus-core/src/mux/conn_worker.rs
@@ -104,7 +104,7 @@ where
                         Some(Err(err)) => {
                             if self.info.connection_type() != ConnectionType::Client {
                                 // we don't care CLI client disconnected
-                                error!("Failed to receive message: {}.", err);
+                                warn!("Connection receive stream closed: {}.", err);
                             }
                             return Err(SwbusError::connection(
                                 SwbusErrorCode::ConnectionError,

--- a/crates/swbus-edge/src/core_client.rs
+++ b/crates/swbus-edge/src/core_client.rs
@@ -13,7 +13,7 @@ use tonic::metadata::MetadataValue;
 use tonic::transport::Endpoint;
 use tonic::Request;
 use tonic::Streaming;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 pub struct SwbusCoreClient {
     uri: String,
@@ -179,7 +179,7 @@ impl SwbusCoreClient {
 
                 // gRPC error was sent by the sender instead of a valid response message.
                 Err(e) => {
-                    error!("Failed to receive message: {}.", e);
+                    warn!("Connection receive stream closed: {}.", e);
                     return Err(SwbusError::connection(
                         SwbusErrorCode::ConnectionError,
                         io::Error::new(io::ErrorKind::ConnectionReset, e.to_string()),


### PR DESCRIPTION
### Description of PR

Summary:

During intentional HA process crash and restart tests, peer swbus connections can close abruptly. Tonic reports these expected transport closures as errors such as:

```text
h2 protocol error: error reading a body from connection
```

The swbus receive loops previously logged every stream error at `ERROR` severity. This caused Log Analyzer failures even though the connection cleanup, route removal, and reconnection paths operated as designed.

This change logs receive-stream closure at `WARN` severity in both `swbus-core` and `swbus-edge`. Error propagation and recovery behavior are unchanged.

Reviewer entry points:

- `crates/swbus-core/src/mux/conn_worker.rs`
- `crates/swbus-edge/src/core_client.rs`

No new dependencies are required.

Fixes https://github.com/sonic-net/sonic-mgmt/issues/26217

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach

#### What is the motivation for this PR?

HA process crash tests intentionally terminate or restart processes and containers. Existing HTTP/2 streams can therefore close with connection reset, broken pipe, or timeout errors.

These events already trigger the expected swbus recovery path:

1. The connection worker exits with a connection error.
2. Routes associated with the connection are unregistered.
3. The connection store marks the connection lost.
4. Client-owned connections reconnect.

Logging the initial stream closure at `ERROR` incorrectly presents this recoverable lifecycle event as a functional failure and causes unnecessary Log Analyzer failures.

#### How did you do it?

Changed the receive-stream closure log from `error!` to `warn!` in:

- The swbus core connection worker.
- The swbus edge client receive loop.

The message was also changed from:

```text
Failed to receive message
```

to:

```text
Connection receive stream closed
```

The returned error, route cleanup, connection-loss handling, and reconnect behavior remain unchanged.

The implementation does not depend on matching Tonic status codes or Hyper error text, which can represent unrelated failures or change between dependency versions.

#### How did you verify/test it?

Unit and integration tests:

```text
cargo test -p swbus-core -p swbus-edge

36 passed; 0 failed
```

Debian packaging:

```text
dpkg-buildpackage -us -uc -b -d
```

Successfully built and verified `dash-ha_1.0.0_amd64.deb`.

Physical SmartSwitch validation:

- Deployed the package to `dash-hadpu0` through `dash-hadpu3` on both switches.
- Verified all `swbusd` and `hamgrd` processes were running the updated binaries.
- Verified bidirectional swbus connectivity with 3/3 successful pings in both directions.
- Ran `test_crash_active_npu_traffic_on_active[hamgrd]`.
- HA crash and recovery completed with 133/133 packets received and 0% traffic loss.
- Observed 15 expected HTTP/2 stream closures:
  - Old `ERR/ERROR Failed to receive message` events: 0
  - New `WARNING/WARN Connection receive stream closed` events: 15

The pytest run still reported an unrelated Log Analyzer teardown error from `orchagent` failing to remove referenced HA scope/set objects. No swbus HTTP/2 closure was reported at `ERROR` severity.

#### Any platform specific information?

No. The change applies to generic swbus gRPC stream handling. Physical validation was performed on NVIDIA SN4280 SmartSwitches.

### Documentation

No documentation update is required. This change only corrects log severity and wording; it does not modify public behavior or configuration.
